### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,41 @@
+FROM ubuntu:22.04
+ARG USERNAME=sonata
+# Install nix, git and cmake (required to build sonata-system software,
+# temporary addition to this dockerfile until we have software build setup in
+# sonata-software).
+RUN apt update -y
+RUN apt install curl git sudo -y
+
+# Setup user
+RUN adduser --disabled-password --gecos "" --uid 1001 $USERNAME \
+    && usermod -aG sudo $USERNAME \
+    && sed -i 's/\(%sudo.*\) ALL/\1 NOPASSWD:ALL/' /etc/sudoers
+
+# Switch to user
+USER $USERNAME
+
+# Install nix
+RUN curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install linux \
+  --extra-conf "sandbox = false" \
+  --init none \
+  --no-confirm
+
+RUN sudo chown -R $USERNAME /nix
+
+ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
+
+# Setup lowRISC nix cache and devshell bash prompt
+RUN sudo bash -c 'echo "substituters = https://cache.nixos.org https://nix-cache.lowrisc.org/public/" >> /etc/nix/nix.conf' \
+  && sudo bash -c 'echo "trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=  nix-cache.lowrisc.org-public-1:O6JLD0yXzaJDPiQW1meVu32JIDViuaPtGDfjlOopU7o=" >> /etc/nix/nix.conf' \
+  && sudo bash -c "echo trusted-users = $USERNAME >> /etc/nix/nix.conf" \
+  && sudo bash -c "echo 'bash-prompt = \[\e[1m\]Sonata \[\e[0m\]\w>\040' >> /etc/nix/nix.conf" \
+  && sudo bash -c "echo 'bash-prompt-prefix =' >> /etc/nix/nix.conf" \
+  && mkdir -p /home/$USERNAME/.local/share/nix \
+  && echo '{"extra-substituters":{"https://nix-cache.lowrisc.org/public/":true},"extra-trusted-public-keys":{"nix-cache.lowrisc.org-public-1:O6JLD0yXzaJDPiQW1meVu32JIDViuaPtGDfjlOopU7o=":true}}' > /home/$USERNAME/.local/share/nix/trusted-settings.json
+
+# Download/build/install everything required for the nix devshell by starting it
+# to run 'true' and immediately exit
+RUN nix develop "github:lowRISC/sonata-software" -c "true"
+
+ENV SHELL /bin/bash
+CMD nix develop "github:lowRISC/sonata-software"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+  "image": "ghcr.io/gregac/sonata-software-container:latest",
+  "remoteUser": "sonata",
+  "containerUser": "sonata",
+  "onCreateCommand": "git submodule init && git submodule update --init --recursive",
+  "settings": {
+    "terminal.integrated.profiles.linux": {
+      "Nix devshell": {
+        "path": "nix",
+        "args": [
+           "develop",
+           "github:lowRISC/sonata-software"
+        ]
+      }
+    },
+    "terminal.integrated.defaultProfile.linux": "Nix devshell"
+  }
+}


### PR DESCRIPTION
This allows a github codespaces setup for building Sonata software.

For now it points to a container that's under my user, the lowRISC org is setup such that I cannot just publish a public container image. I think if we setup some automated build and publish from this repository we can get the container under the lowrisc namespace on ghcr.io but this current setup will do the job for now.

To check out the codespace go to my branch here: https://github.com/GregAC/sonata-software/tree/devcontainer click on 'Code' and choose the 'Codespaces' tab. You should see a green 'Create codespace on devcontainer' click this and it'll setup a codespce.

It'll take a few minutes to create, you will eventually see a vscode UI. In the bottom panel (which has the terminal) you'll see a + icon in the top right of the panel click this and you should see a new terminal open that give the prompt 'Sonata /workspaces/sonata-software>' this is a nix devshell. This has the toolchain all setup so should be able to cd into '/workspace/sonata-system' then build the software following the docs: https://github.com/lowRISC/sonata-system/tree/main/sw/cheri