### PR TITLE
Added some I2C example code.

### DIFF
--- a/compartments/i2c_example.cc
+++ b/compartments/i2c_example.cc
@@ -1,0 +1,76 @@
+// Copyright lowRISC Contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <ctype.h>
+#include <compartment.h>
+#include <debug.hh>
+#include <thread.h>
+#include <platform-i2c.hh>
+
+/// Expose debugging features unconditionally for this compartment.
+using Debug = ConditionalDebug<true, "i2c example">;
+
+template<class T> using Mmio = volatile T*;
+
+/// Read from the AS612 Temperature Sensor
+static void read_temperature_sensor_value(Mmio<OpenTitanI2c> i2c, const char* regName, const uint8_t RegIdx)
+{
+	uint8_t buf[2] = {RegIdx, 0};
+	i2c->write(0x48, buf, 1, false);
+	if(i2c->read(0x48, buf, 2u)) {
+		uint16_t temp = (buf[0] << 8) | buf[1];
+		Debug::log("The {} readout is {}", regName, temp);
+	} else {
+		Debug::log("Could not read the {}", regName);
+	}
+}
+
+
+static void id_eeprom_report(Mmio<OpenTitanI2c> i2c, const uint8_t IdAddr) {
+	uint8_t addr[2] = {0};
+	i2c->write(0x50u, addr, 2, true);
+
+	static uint8_t data[0x80];
+	// Initialize the buffer to known contents in case of read issues.
+	memset(data, 0xddu, sizeof(data));
+
+	if (!i2c->read(IdAddr, data, sizeof(data))) {
+		Debug::log("Failed to read EEPROM ID of device at address {}", IdAddr);
+	}
+
+	Debug::log("EEPROM ID of device at address {}:", IdAddr);
+	for (size_t idx = 0u; idx + 4 < sizeof(data); idx += 4)
+	{
+		auto asChar = [](uint8_t val) -> char {
+			return static_cast<char>(isprint(val) ? val : '.');
+		};
+		Debug::log(
+			"\t{}{}{}{} | {} {} {} {}",
+			asChar(data[idx + 0]), asChar(data[idx + 1]), asChar(data[idx + 2]), asChar(data[idx + 3]),
+			data[idx + 0], data[idx + 1], data[ idx + 2], data[idx + 3]
+		);
+	}
+
+}
+
+[[noreturn]]
+void __cheri_compartment("i2c_example") run()
+{
+	auto i2cSetup = [](Mmio<OpenTitanI2c> i2c) {
+		i2c->reset_fifos();
+		i2c->set_host_mode();
+		i2c->set_speed(100);
+	};
+	auto i2c0 = MMIO_CAPABILITY(OpenTitanI2c, i2c0);
+	auto i2c1 = MMIO_CAPABILITY(OpenTitanI2c, i2c1);
+	i2cSetup(i2c0);
+	i2cSetup(i2c1);
+
+	id_eeprom_report(i2c0, 0x50);
+
+	read_temperature_sensor_value(i2c1, "temporature sensor configuration", 1);
+	while(true) {
+		read_temperature_sensor_value(i2c1, "temporature", 0);
+		thread_millisecond_wait(4000);
+	}
+}


### PR DESCRIPTION
This example expects the RaspberryPiSenseHAT to be attached, as well a AS612 Temperature Sensor.
I've created a second firmware image because of this requirement.

Output from the `sonata_everything_demo` image:

```
bootloader: Loading software from flash...
bootloader: Booting into program, hopefully.
led walk compartment: Look pretty LEDs!
i2c example: EEPROM ID of device at address 0x50:
i2c example:    R-Pi | 0x52 0x2d 0x50 0x69
i2c example:    .... | 0x1 0x0 0x3 0x0
i2c example:    .... | 0xf0 0x3 0x0 0x0
i2c example:    .... | 0x1 0x0 0x0 0x0
i2c example:    -... | 0x2d 0x0 0x0 0x0
i2c example:    .X.. | 0xe7 0x58 0xd1 0x95
i2c example:    .V(. | 0xf1 0x56 0x28 0xab
i2c example:    .N.B | 0xcb 0x4e 0x99 0x42
i2c example:    .y.. | 0xc7 0x79 0xd6 0xa3
i2c example:    .... | 0x1 0x0 0x1 0x0
i2c example:    ..Ra | 0xc 0x9 0x52 0x61
i2c example:    spbe | 0x73 0x70 0x62 0x65
i2c example:    rry  | 0x72 0x72 0x79 0x20
i2c example:    PiSe | 0x50 0x69 0x53 0x65
i2c example:    nse  | 0x6e 0x73 0x65 0x20
i2c example:    HAT. | 0x48 0x41 0x54 0x7f
i2c example:    .... | 0x0 0x0 0x0 0x0
i2c example:    .... | 0x0 0x0 0x0 0x0
i2c example:    .... | 0x0 0x0 0x0 0x0
i2c example:    .... | 0x0 0x0 0x0 0x0
i2c example:    .... | 0x0 0x0 0x0 0x0
i2c example:    .... | 0x0 0x0 0x0 0x0
i2c example:    .... | 0x0 0x0 0x0 0x0
i2c example:    .... | 0x0 0x0 0x0 0x0
i2c example:    .... | 0x0 0x0 0x0 0x0
i2c example:    .... | 0x0 0x0 0x0 0x0
i2c example:    .... | 0x0 0x0 0x0 0x0
i2c example:    .... | 0x0 0x0 0x0 0x0
i2c example:    .... | 0x0 0x0 0x0 0x0
i2c example:    .... | 0x0 0x0 0x0 0x0
i2c example:    .... | 0x0 0x0 0x0 0x0
i2c example: The temporature sensor configuration readout is 0x40ff
i2c example: The temporature readout is 0xc35
i2c example: The temporature readout is 0xc34
i2c example: The temporature readout is 0xc34
i2c example: The temporature readout is 0xc35
```

~~*Draft because it depends on https://github.com/lowRISC/cheriot-rtos/pull/1*~~