### PR TITLE
Add boot stub env var to env-with-sim nix devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,12 @@
         };
         env-with-sim = pkgs.mkShell {
           name = "sonata-sw-with-sim";
-          packages = default.nativeBuildInputs ++ [sonataSystemPkgs.sonata-simulator];
+          packages =
+            [sonataSystemPkgs.sonata-simulator]
+            ++ default.nativeBuildInputs;
+          shellHook = ''
+            export SONATA_SIM_BOOT_STUB=${sonataSystemPkgs.sonata-sim-boot-stub.out}/share/sim_boot_stub
+          '';
         };
       };
       checks = {


### PR DESCRIPTION
The Sonata simulator nix package includes a boot stub binary. This adds an environment variable to the env-with-sim nix devshell that gives the path to the stub binary.

This should only be merged when https://github.com/lowRISC/sonata-system/pull/102 has been merged and the flake.lock updated on this PR.