### PR TITLE
Changes necessary for Proximity demo

### DIFF
--- a/examples/all/proximity_sensor_example.cc
+++ b/examples/all/proximity_sensor_example.cc
@@ -92,17 +92,17 @@ static uint8_t read_proximity_sensor(Mmio<OpenTitanI2c> i2c)
 		i2c->speed_set(1);
 	};
 
-	auto i2c0 = MMIO_CAPABILITY(OpenTitanI2c, i2c0);
-	i2cSetup(i2c0);
+	auto i2c1 = MMIO_CAPABILITY(OpenTitanI2c, i2c1);
+	i2cSetup(i2c1);
 	uint8_t addr;
 
 	auto rgbled = MMIO_CAPABILITY(SonataRgbLedController, rgbled);
 
-	setup_proximity_sensor(i2c0, ApdS9960I2cAddress);
+	setup_proximity_sensor(i2c1, ApdS9960I2cAddress);
 
 	while (true)
 	{
-		uint8_t prox = read_proximity_sensor(i2c0);
+		uint8_t prox = read_proximity_sensor(i2c1);
 		Debug::log("Proximity is {}\r", prox);
 		rgbled->rgb(SonataRgbLed::Led0, ((prox) >> 3), 0, 0);
 		rgbled->rgb(SonataRgbLed::Led1, 0, (255 - prox) >> 3, 0);

--- a/examples/xmake.lua
+++ b/examples/xmake.lua
@@ -91,6 +91,44 @@ firmware("sonata_demo_everything")
     end)
     after_link(convert_to_uf2)
 
+-- Demo that does proximity test as well as LCD screen, etc for demos.
+firmware("sonata_proximity_demo")
+    add_deps("freestanding", "led_walk_raw", "echo", "lcd_test", "proximity_sensor_example")
+    on_load(function(target)
+        target:values_set("board", "$(board)")
+        target:values_set("threads", {
+            {
+                compartment = "led_walk_raw",
+                priority = 2,
+                entry_point = "start_walking",
+                stack_size = 0x200,
+                trusted_stack_frames = 1
+            },
+            {
+                compartment = "echo",
+                priority = 1,
+                entry_point = "entry_point",
+                stack_size = 0x200,
+                trusted_stack_frames = 1
+            },
+            {
+                compartment = "lcd_test",
+                priority = 2,
+                entry_point = "lcd_test",
+                stack_size = 0x1000,
+                trusted_stack_frames = 1
+            },
+            {
+                compartment = "proximity_sensor_example",
+                priority = 2,
+                entry_point = "run",
+                stack_size = 0x200,
+                trusted_stack_frames = 1
+            }
+        }, {expand = false})
+    end)
+    after_link(convert_to_uf2)
+
 -- A firmware image that only walks LEDs
 firmware("sonata_led_demo")
     add_deps("freestanding", "debug")


### PR DESCRIPTION
This generates a demo UF2 that shows the screen, LED walk along with the proximity test. It also changes the proximity test to use I2C1 which is on the side of the Sonata board and makes it easier to prop the board up for demos.