### PR TITLE
Set up the mdbook-replace preprocessor

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -10,3 +10,24 @@ title = "Sonata Software"
 [output.html]
 git-repository-url = "https://github.com/lowRISC/sonata-software"
 edit-url-template = "https://github.com/lowRISC/sonata-software/edit/main/{path}"
+
+[preprocessor.replace]
+after = ["links"]
+
+# Replace all links to a README.md to an index.md
+link_replacements = [
+    {regex = '^(?P<path>[^:#\?]*)README\.md(?P<suffix>[?#].*)?', replacement = '${path}index.md${suffix}'},
+]
+
+[[preprocessor.replace.local_link_replacements]]
+# Replace all paths pointing to something in the cheriot-rtos
+# to a link pointing to them in github.
+regex = '^cheriot-rtos/*(?P<path>.*)?'
+replacement = 'https://github.com/CHERIoT-Platform/cheriot-rtos/tree/main/${path}'
+
+[[preprocessor.replace.local_link_replacements]]
+# Replace all paths pointing to something in this repository,
+# that is not a markdown file or image,
+# to a link pointing to them in github.
+regex = '[^:#\?]*[^(\.(md|svg|png))]([?#].*)?'
+replacement = 'https://github.com/lowRISC/sonata-software/tree/main/${0}'

--- a/flake.lock
+++ b/flake.lock
@@ -18,9 +18,27 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "lowrisc-nix": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs",
         "poetry2nix": "poetry2nix",
         "rust-overlay": "rust-overlay"
@@ -37,6 +55,27 @@
         "owner": "lowRISC",
         "repo": "lowrisc-nix",
         "type": "github"
+      }
+    },
+    "mdutils": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1725192075,
+        "narHash": "sha256-qsLSiEZ5wJd/4xkTF1FPcMXYGZNi3RORXi++TM64SOg=",
+        "ref": "refs/heads/main",
+        "rev": "36c8cc38d5b09c81cb233e0c8bccb128be4d5a5e",
+        "revCount": 28,
+        "type": "git",
+        "url": "https://codeberg.org/HU90m/mdutils.git"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://codeberg.org/HU90m/mdutils.git"
       }
     },
     "nix-github-actions": {
@@ -91,7 +130,7 @@
           "lowrisc-nix",
           "nixpkgs"
         ],
-        "systems": "systems_2",
+        "systems": "systems_3",
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
@@ -118,6 +157,7 @@
           "sonata-system",
           "lowrisc-nix"
         ],
+        "mdutils": "mdutils",
         "nixpkgs": [
           "lowrisc-nix",
           "nixpkgs"
@@ -196,6 +236,21 @@
       }
     },
     "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,10 @@
     lowrisc-nix.follows = "sonata-system/lowrisc-nix";
     nixpkgs.follows = "lowrisc-nix/nixpkgs";
     flake-utils.follows = "lowrisc-nix/flake-utils";
+    mdutils = {
+      url = "git+https://codeberg.org/HU90m/mdutils.git";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   nixConfig = {
@@ -20,12 +24,14 @@
     flake-utils,
     lowrisc-nix,
     sonata-system,
+    mdutils,
   }: let
     system_outputs = system: let
       version = "0.0.1";
 
       pkgs = import nixpkgs {inherit system;};
       lrPkgs = lowrisc-nix.outputs.packages.${system};
+      mdutilsPkgs = mdutils.outputs.packages.${system};
       lrDoc = lowrisc-nix.lib.doc {inherit pkgs;};
       sonataSystemPkgs = sonata-system.outputs.packages.${system};
       cheriotPkgs = lowrisc-nix.outputs.devShells.${system}.cheriot.nativeBuildInputs;
@@ -48,6 +54,7 @@
           root = ./.;
           fileset = lrDoc.standardMdbookFileset ./.;
         };
+        buildInputs = [mdutilsPkgs.default];
       };
 
       sonata-tests = pkgs.stdenvNoCC.mkDerivation ({
@@ -156,7 +163,7 @@
       devShells = rec {
         default = pkgs.mkShell {
           name = "sonata-sw";
-          packages = cheriotPkgs ++ [lrPkgs.uf2conv pkgs.python3Packages.pyserial];
+          packages = cheriotPkgs ++ [lrPkgs.uf2conv pkgs.python3Packages.pyserial mdutilsPkgs.default];
         };
         env-with-sim = pkgs.mkShell {
           name = "sonata-sw-with-sim";


### PR DESCRIPTION
If you pop over to [the site](https://lowrisc.github.io/sonata-software/exercises/hardware_access_control/index.html), you'll notice the links to local files such as `xmake.lua` don't work. This fixes that by switching these links out for links to them on github.