### PR TITLE
Simplified and fixed mdbook-replace regexs

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -14,20 +14,20 @@ edit-url-template = "https://github.com/lowRISC/sonata-software/edit/main/{path}
 [preprocessor.replace]
 after = ["links"]
 
-# Replace all links to a README.md to an index.md
+# Replace all links to a README.md to with a link to an index.md
 link_replacements = [
     {regex = '^(?P<path>[^:#\?]*)README\.md(?P<suffix>[?#].*)?', replacement = '${path}index.md${suffix}'},
 ]
 
 [[preprocessor.replace.local_link_replacements]]
-# Replace all paths pointing to something in the cheriot-rtos
-# to a link pointing to them in github.
-regex = '^cheriot-rtos/*(?P<path>.*)?'
+# Replace all paths pointing to something in cheriot-rtos
+# to a link pointing to it in github.
+regex = '^cheriot-rtos/(?P<path>.*)?'
 replacement = 'https://github.com/CHERIoT-Platform/cheriot-rtos/tree/main/${path}'
 
 [[preprocessor.replace.local_link_replacements]]
 # Replace all paths pointing to something in this repository,
-# that is not a markdown file or image,
-# to a link pointing to them in github.
-regex = '[^:#\?]*[^(\.(md|svg|png))]([?#].*)?'
+# that ends with .cc, .hh, .h, .rego, .lua or / (for directories)
+# to a link pointing to to in github.
+regex = '.*(\/|\.(cc|hh|h|rego|lua))$'
 replacement = 'https://github.com/lowRISC/sonata-software/tree/main/${0}'


### PR DESCRIPTION
The local file replacement for files in the repository was capturing markdown files. The new regex is a white list. Note, it only assumes something is a register if it ends with `/`.