### PR TITLE
Add `cheriot-audit` docs & exercises

### DIFF
--- a/doc/auditing-firmware.md
+++ b/doc/auditing-firmware.md
@@ -1,0 +1,174 @@
+# Auditing Firmware
+
+This documentation provides an introduction to CHERIoT Audit, alongside a quick guide on developing auditing policies with Rego.
+You can find more comprehensive information about these tools in their relevant documentation:
+ - [**CHERIoT Audit**](https://github.com/CHERIoT-Platform/cheriot-audit/blob/main/README.md): the source for `cheriot-audit`.
+ - [**Rego OPA Documentation**](https://www.openpolicyagent.org/docs/latest/policy-language/): documentation for Rego, the policy language used by CHERIoT Audit.
+ - [**CHERIoT Programmer's Guide**](https://cheriot.org/book/): CHERIoT documentation, which contains some small sections about auditing CHERIoT.
+
+## Introduction
+
+When building firmware, the CHERIoT RTOS linker will produce JSON reports that describe the contents and interactions of each compartment.
+CHERIoT Audit is a tool that takes these less-comprehensible JSON reports, and consumes them via a policy language called [Rego][] by evaluating a query to produce an output.
+
+[Rego]: https://www.openpolicyagent.org/docs/latest/policy-language/
+
+Rego is a (mostly) declarative programming language which is similar to other logic programming languages like Datalog and Prolog.
+It can be used by firmware integrators to write policies, which can then be verified automatically after linking firmware with CHERIoT Audit.
+Making use of effective compartmentalisation alongside CHERIoT Audit can help enhance supply-chain security, enabling safe sharing even if an attacker partially compromises your software.
+On top of this, it can simultaneously be used to enforce rules on compartments that you develop, to protect against bugs and misconfigurations.
+
+## Using CHERIoT Audit
+
+When using CHERIoT Audit, you must specify the following three options:
+ - `-b`/`--board`: the board description JSON file (`sonata.json`).
+ - `-j`/`--firmware-report`: the JSON report emitted by the CHERIoT RTOS linker.
+ - `-q`/`--query`: the Rego query to run on the report.
+
+First, make sure you have followed the [getting started guide][] to setup your Nix development environment, and then build the examples using the [standard build flow][].
+After building the example software, you can query the exports of the `echo` compartment in the `sonata_demo_everything` report:
+
+[getting started guide]: ../doc/getting-started.md
+[standard build flow]: ../doc/exploring-cheriot-rtos.md#build-system
+
+```sh
+# Run from the root of the sonata-software repository
+cheriot-audit --board=cheriot-rtos/sdk/boards/sonata.json \
+              --firmware-report=build/cheriot/cheriot/release/sonata_demo_everything.json \
+              --query='input.compartments.echo.exports'
+```
+
+This should then output something like this:
+```json
+[{"export_symbol":"__export_echo__Z11entry_pointv", "exported":true, "interrupt_status":"enabled",
+  "kind":"Function", "register_arguments":0, "start_offset":16}]
+```
+This output tells us that a single entry point is being exported by the `echo` compartment, which is a function that runs with interrupts enabled and takes no register arguments.
+
+## Developing with Rego
+
+The [`vscode-opa`](https://www.openpolicyagent.org/integrations/vscode-opa/) extension for VSCode and the [`zed-rego`][] extension for Zed provide syntax highlighting and a language server for linting functionality.
+
+[`vscode-opa`]: https://www.openpolicyagent.org/integrations/vscode-opa/
+[`zed-rego`]: https://github.com/StyraInc/zed-rego
+
+Rego operates using a few key abstractions known as *documents*:
+- `input`, the input document, is the firmware report JSON files. There are also other input documents such as the board description.
+- A set of modules (also known as *virtual documents*), which process the input documents in order to provide us with views that can then be further interpreted or convey more comprehensible information.
+You can write your own modules to encapsulate policy for your specific firmware, or use modules created by others.
+For example, `cheriot-audit` supports modules for the RTOS and core compartmentalisation abstractions, such as `data.rtos.decode_allocator_capability`.
+
+These documents are then evaluated over a given Rego query to produce a JSON output.
+In order to drive automated auditing compliance or signing decisions, this result will be a single value or some Boolean result representing validity.
+
+> ⚠️ Rego as a language has weakly-typed semantics.
+> Running policies via `cheriot-audit` will report only some basic semantic errors.
+> For example, accessing a key/attribute that does not exist will not raise an error as you may expect, but will instead result in an **undefined decision**.
+> CHERIoT Audit currently represents undefined values using an **empty output**.
+>
+> It is recommended to create appropriately modular policy code (see below) and test incrementally and often to avoid issues arising.
+
+### Creating modules
+
+Writing a policy within a query string quickly becomes untenable; a better approach involves creating a Rego module and defining functions and predicates that encapsulate complex policy logic in a modular fashion.
+These rules can then be easily and programatically invoked via a simple query.
+For example, you could make a policy file `policies/example.rego` with the following structure:
+
+```python  # This is Rego, not Python, but we at least get a tiny bit of highlighting
+package my_example
+
+import future.keywords
+
+example_function_1(arg1, arg2) {
+    ...
+}
+
+example_function2() {
+    ...
+}
+```
+You might then use `cheriot-audit` via a command like:
+```sh
+cheriot-audit --board=cheriot-rtos/sdk/boards/sonata.json \
+              --firmware-report=build/cheriot/cheriot/release/sonata_demo_everything.json \
+              --module=policies/examples.rego \
+              --query='data.my_example.example_function1("test", input.compartments)'
+```
+Where `data.my_example` refers to the `my_example` package declared in your included module.
+In this fashion, you can define readable and maintainable policies, and easily audit desired properties with a simple query.
+
+### A quick introduction to Rego
+
+Rego is a policy language designed similarly to Datalog, which is a declarative logic inference programming language.
+As such, much of Rego's semantics will be familiar if you already know a logic programming language like Prolog, ASP or Datalog.
+Otherwise, it may be unfamiliar and unintuitive otherwise.
+If you have no such prior experience, it is highly recommended to read over the [Rego documentation][].
+
+[Rego documentation]: https://www.openpolicyagent.org/docs/latest/policy-language/
+
+In documents you create *policies*, which are defined by one or more *rules*.
+Rules are in turn each composed of an assignment and a condition.
+A rule with no assignments evaluates to `true` by default if its condition is satisfied, and a rule with no condition is automatically assigned.
+
+Rules can be written as `name := val {condition}`, where `val` can be either a Scalar or Composite value.
+Composite values are arrays, objects or sets, which are created and accessed using semantics similar to Python, e.g. `rect := {"width": 2, "height": 4}` and `numbers = {1, 7, 19}`.
+- You can interpret the rule syntax `a := b {c}` as meaning `a IS b IF c`.
+- `:=` is the assignment operator.
+It assigns values to locally scoped variables/rules.
+- `==` is the comparison operator, and checks for JSON equality.
+- `=` is the *unification* operator.
+It combines assignment and comparison, with Rego assigning (binding) variables to values that make the comparison true.
+This lets you declaratively ask for values that make an expression true.
+
+If the body of a rule will never evaluate to `true`, e.g. `v if "a" = "b"`, then the rule is `undefined`.
+This means that any expressions using its value will also be `undefined`.
+
+> ℹ️ There is a notable exception to this rule: the `not` keyword acts as follows.
+> If the value is `true`, then `not true` is `false`.
+Otherwise, if the value is anything else, *including `undefined`*, then the negation of that value is `true`.
+
+Each rule can have multiple conditions.
+Rule bodies, marked by braces, are either delimited by semi-colons, or require you to separate individual expressions with newlines.
+*Note here that Rego has whitespace-dependent semantics*.
+
+
+Variables can be freely used to define rules. For example, `t if { a:= 12; b := 34; b > a}`.
+When evaluating rule bodies, OPA searches for any variable bindings that make all of the expressions true - multiple such bindings may exist.
+This unification strategy is similar to the one found in [Prolog][], where variables in Rego are existentially quantified by default:
+- If we have `a := [1, 2, 3]; a[i] = 3`, then the query is satisfied if there exists such an `i` such that all of the query's expressions are simultaneously satisfied.
+In this case, `i=2` (note: arrays are zero-indexed).
+- Universal quantification ("for all") can be performed using the syntactic sugar `every` keyword, or by negating the corresponding existentially quantified negated expression. For those familiar with logic syntax, this uses `∀x: p == ¬(∃x : ¬p)`.
+
+[Prolog]: https://www.dai.ed.ac.uk/groups/ssp/bookpages/quickprolog/node12.html
+
+Compound rule bodies can be understood as the logical conjunction (AND) of each individual expression.
+If any single condition evaluates to `false`, then so does the whole rule body.
+In contrast, any rule with multiple definitions is checked in-order until a matching definition is found.
+This can be understood as the logical disjunction (OR) of each individual rule.
+
+Rego supports standard list and set operations, as well as comprehensions in the format
+```
+{mapped_output | iterator binding ; conditional_filters}
+````
+where conditional filtering is optional.
+For example, consider the list comprehension:
+```python  # This is Rego, not python, but it gives us some syntax highlighting
+[ { "owner": owner, "capability": data.rtos.decode_allocator_capability(c) } |
+c := input.compartments[owner].imports[_] ; data.rtos.is_allocator_capability(c) ]
+```
+Thich is analogous to the following Python list comprehension:
+```python
+[{"owner": owner, "capability": data.rtos.decode_allocator_capability(c)}
+ for owner, value in input.compartments.items()
+ for c in value.imports
+ if data.rtos.is_allocator_capability(c)]
+```
+
+Objects in Rego can be seen as unordered key-value collections, where any type can be used as a key.
+Attributes can be accessed via the `object["attr"]` syntax, or using `object.attr` for string attributes.
+Back-ticks can be used to create a raw string, which is useful when writing regular expressions for example.
+
+Rego supports functions with the standard function syntax e.g. `foo() := { ... }` or `bar(arg1, arg2) { ... }`.
+These are then invoked like `foo()` or `bar(5, {"x": 3, "y": 4})`. Functions may have many inputs, but only one output.
+Because of Rego's evaluation strategy, function arguments can also be constant terms - for example `foo([x, {"bar": y}]) := { ... }`.
+Alongside Rego's existential quantification and unification rules, this can be used in a similar manner to pattern matching in higher-level languages.

--- a/exercises/README.md
+++ b/exercises/README.md
@@ -16,4 +16,6 @@ xmake -P exercises
 
 ## Exercises
 
-Currently, there is one exercise: [Hardware Access Control](./hardware_access_control/)
+Currently, there are two exercises:
+ - [Hardware Access Control](./hardware_access_control/)
+ - [Firmware Auditing](./firmware_auditing/)

--- a/exercises/firmware_auditing/README.md
+++ b/exercises/firmware_auditing/README.md
@@ -1,0 +1,86 @@
+<!--
+Copyright lowRISC Contributors.
+SPDX-License-Identifier: Apache-2.0
+-->
+# Firmware Auditing Exercise
+
+First, make sure to go to the [building the exercises][] section to see how the exercises are built.
+
+[building the exercises]: ../README.md#building-the-exercises
+
+You might find it useful to look at the [auditing firmware][] documentation to get a brief introduction to `cheriot-audit` and the Rego policy language.
+
+[auditing firmware]: ../../doc/auditing-firmware.md
+
+In this exercise, we use the `cheriot-audit` tool to audit the JSON firmware reports produced by the CHERIoT RTOS linker.
+This will let us assert a properties about our firmware images at link-time, guaranteeing desired safety checks.
+This exercise explores a set of self-contained policies which audit a variety of properties, to give an idea of what can be achieved using CHERIoT Audit.
+
+For this exercise, when the `xmake.lua` build file is mentioned, we are referring to [`exercises/firmware_auditing/xmake.lua`][].
+
+[`exercises/firmware_auditing/xmake.lua`]: ../../exercises/firmware_auditing/xmake.lua
+
+## Part 1 - check that firmware contains no sealed capabilities
+
+Policies are written using the *Rego* language, which has syntax that may be unfamiliar.
+If you find yourself confused whilst going through this exercise, it might be helpful to read over the [introduction to Rego][] in the documentation.
+
+[introduction to Rego]: ../../doc/auditing-firmware.md#a-quick-introduction-to-rego
+
+The policy for this exercise can be found in the [`no_sealed_capabilities.rego`][] file.
+You can either follow along as this exercise explains how the policy works, or try writing your own policy with the same behaviour.
+The firmware we are auditing is `firmware_auditing_part_1`, defined in [`xmake.lua`][], which contains one compartment based on the C++ file [`sealed_capability.cc`][].
+This is just a toy example, to show off the auditing functionality.
+
+[`no_sealed_capabilities.rego`]:  ../../exercises/firmware_auditing/part_1/no_sealed_capabilities.rego
+[`xmake.lua`]: ../../exercises/firmware_auditing/xmake.lua
+[`sealed_capability.cc`]:  ../../exercises/firmware_auditing/part_1/sealed_capability.cc
+
+The first thing that this policy does is declares a `no_seal` package.
+This is to allow us to include the file as a module when invoking `cheriot-audit`, so that we can just refer to `data.no_seal` to call our implemented functions.
+A very simple function `is_sealed_capability` is then defined, which takes the JSON representing a given `capability`, and checks its `kind` attribute to determine whether it is a sealed capability or not.
+
+Next, we use Rego's functionality to create a rule `no_sealed_capabilities_exist`, which should evaluate to `true` only if no sealed capabilities are used in any of the firmware's compartments.
+To do this, we perform a list comprehension, unifying with a wildcard variable to iterate over and filter all imported capabilities of all compartments in the firmware.
+We then use the built-in`count` function to ensure that the resulting array is empty.
+
+Skipping to the end of the file, we can then create a simple Boolean `valid` rule which corresponds to whether `no_sealed_capabilities_exist` is defined or not.
+To convert the undefined value to a Boolean, we use the `default` keyword, which lets us provide a `false` asignment as a fall-through if no other rule definitions match.
+
+We can run this policy on our example firmware using the following command:
+
+```sh
+cheriot-audit --board=cheriot-rtos/sdk/boards/sonata.json \
+              --firmware-report=build/cheriot/cheriot/release/firmware_auditing_part_1.json \
+              --module=exercises/firmware_auditing/part_1/no_sealed_capabilities.rego \
+              --query='data.no_seal.valid'
+```
+
+Because `sealed_capability.cc` currently doesn't use any sealed capabilities, this policy should evalute to `true`.
+
+Now, navigate to [`sealed_capability.cc`][] and comment out or remove the line `uint32_t arr[ArrSize];`.
+Then, uncomment or add the line `uint32_t *arr = new uint32_t[ArrSize];`.
+This will change the array `arr` from being allocated on the stack to the heap.
+Rebuilding the exercises (using `xmake -P exercises`) and running the same command again should now cause the policy to evaluate to `false`.
+
+[`sealed_capability.cc`]: ../../exercises/firmware_auditing/part_1/sealed_capability.cc
+
+However, it may not immediately be clear why the policy failed.
+When designing such a policy, you can see that it may be helpful to have a rule that lets us inspect the details of any sealed capabilities.
+We do this with our final `sealed_capability_info` rule, which constructs ojects storing the contents, key, and compartment of each sealed capability.
+
+> ℹ️ Note the use of unification here.
+> We iterate over `input.compartments` with the non-defined variable `owner`, and then map the value that is bound this variable to the `owner` field of our new object.
+
+Now, run the `cheriot-audit` command again, but replace `data.no_seal.valid` with `data.no_seal.sealed_capability_info`.
+You should see an output that looks something like this:
+
+```json
+[{"compartment":"alloc", "contents":"00100000 00000000 00000000 00000000 00000000 00000000",
+  "key":"MallocKey", "owner":"sealed_capability"}]
+```
+
+This tells us where the sealed capabilty in our firmware originates - a static sealed object owned by our `sealed_capability` compartment, which is used by the RTOS' allocator for authorising memory allocation.
+Try experimenting by adding more functionality to this toy example!
+For example, try creating your own sealed capabilities and check the result.
+You might also try investigating the values of the different rules that we've made, and filtering or auditing other properties of the capabilities.

--- a/exercises/firmware_auditing/part_1/no_sealed_capabilities.rego
+++ b/exercises/firmware_auditing/part_1/no_sealed_capabilities.rego
@@ -1,0 +1,26 @@
+# Copyright lowRISC Contributors.
+# SPDX-License-Identifier: Apache-2.0
+package no_seal
+
+is_sealed_capability(capability) {
+    capability.kind == "SealedObject"
+}
+
+no_sealed_capabilities_exist {
+    sealedCapabilities := [ cap | cap = input.compartments[_].imports[_] ; is_sealed_capability(cap) ]
+    count(sealedCapabilities) == 0
+}
+
+sealed_capability_info := [
+    {"contents": cap.contents,
+     "key": cap.sealing_type.key,
+     "compartment": cap.sealing_type.compartment,
+     "owner": owner
+    } | cap = input.compartments[owner].imports[_]
+    ; data.no_seal.is_sealed_capability(cap)
+]
+
+default valid = false
+valid = true {
+    no_sealed_capabilities_exist
+}

--- a/exercises/firmware_auditing/part_1/sealed_capability.cc
+++ b/exercises/firmware_auditing/part_1/sealed_capability.cc
@@ -1,0 +1,30 @@
+// Copyright lowRISC Contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <compartment.h>
+#include <platform-gpio.hh>
+#include <thread.h>
+
+static constexpr uint32_t LedIdx  = 7;
+static constexpr size_t   ArrSize = 32;
+
+void __cheri_compartment("sealed_capability") do_things()
+{
+	auto gpio = MMIO_CAPABILITY(SonataGPIO, gpio);
+
+	uint32_t arr[ArrSize];
+	// Comment the above line and uncomment the below line to allocate on the
+	// heap!
+	// uint32_t *arr = new uint32_t[ArrSize];
+
+	for (size_t i = 0; i < ArrSize; i++)
+	{
+		arr[i] = i;
+	}
+
+	while (true)
+	{
+		gpio->led_toggle(LedIdx);
+		thread_millisecond_wait(500);
+	}
+}

--- a/exercises/firmware_auditing/part_2/bad_disable_interrupts.cc
+++ b/exercises/firmware_auditing/part_2/bad_disable_interrupts.cc
@@ -1,0 +1,27 @@
+// Copyright lowRISC Contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <compartment.h>
+
+[[cheri::interrupt_state(disabled)]] int not_allowed()
+{
+	int x = 0;
+	x += 1;
+	return x;
+}
+
+[[gnu::noinline]] int other_function()
+{
+	return 1000000;
+}
+
+/// Thread entry point.
+void __cheri_compartment("bad_disable_interrupts") entry_point()
+{
+	int y = not_allowed();
+	other_function();
+	while (y < other_function())
+	{
+		y += 1;
+	}
+}

--- a/exercises/firmware_auditing/part_2/disable_interrupts.cc
+++ b/exercises/firmware_auditing/part_2/disable_interrupts.cc
@@ -1,0 +1,41 @@
+// Copyright lowRISC Contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <compartment.h>
+
+[[gnu::noinline]] [[cheri::interrupt_state(disabled)]] int
+run_without_interrupts(int x)
+{
+	return x + 1;
+}
+
+[[gnu::noinline]] [[cheri::interrupt_state(disabled)]] void
+also_without_interrupts(int *x)
+{
+	*x = 1;
+}
+
+[[gnu::noinline]] void other_function_one()
+{
+	int x = 3;
+}
+
+[[gnu::noinline]] int other_function_two()
+{
+	return 3;
+}
+
+[[gnu::noinline]] int other_function_three(int arg1, int arg2)
+{
+	return arg1 + arg2;
+}
+
+/// Thread entry point.
+void __cheri_compartment("disable_interrupts") entry_point()
+{
+	other_function_one();
+	int y = other_function_two();
+	y     = run_without_interrupts(3);
+	y += other_function_three(4, 7);
+	also_without_interrupts(&y);
+}

--- a/exercises/firmware_auditing/part_2/interrupt_disables.rego
+++ b/exercises/firmware_auditing/part_2/interrupt_disables.rego
@@ -1,0 +1,66 @@
+# Copyright lowRISC Contributors.
+# SPDX-License-Identifier: Apache-2.0
+package interrupts
+
+import future.keywords
+
+# Note - Any compartment not in this array is not checked by default,
+# and so are allowed to have disabled interrupts.
+required_disabled_interrupts := [
+    {
+        "compartment": "disable_interrupts",
+        "functions": {"run_without_interrupts(int)", "also_without_interrupts(int*)"}
+    }, {
+        "compartment": "bad_disable_interrupts",
+        "functions": {}
+        # Uncomment the below line (and comment the above line) to allow the disallowed
+        # function to be run with interrupts disabled
+        #"functions": {"not_allowed()"}
+    }
+]
+required_compartments := {x.compartment | x = required_disabled_interrupts[_]}
+
+all_exports := [
+    {"owner": owner, "export": export} | export = input.compartments[owner].exports[_]
+]
+
+all_required_compartments_present {
+    compartments := {name | input.compartments[name]}
+    required_compartments == required_compartments & compartments
+}
+
+exports_with_interrupt_status(status) := [
+    export | export = all_exports[_] ; export["export"]["interrupt_status"] = status
+]
+
+patched_export_entry_demangle(compartment, export_symbol) := demangled {
+    startswith(export_symbol, "__library_export_")
+    modified_export = concat("", ["__export_", substring(export_symbol, 17, -1)])
+    demangled := export_entry_demangle(compartment, modified_export)
+}
+patched_export_entry_demangle(compartment, export_symbol) := demangled {
+    not startswith(export_symbol, "__library_export_")
+    demangled := export_entry_demangle(compartment, export_symbol)
+}
+
+compartment_only_required_disabled_interrupts(compartment) {
+    symbols := {
+        patched_export_entry_demangle(e["owner"], e["export"]["export_symbol"]) |
+        e = exports_with_interrupt_status("disabled")[_] ;
+        e["owner"] = compartment["compartment"]
+    }
+    required := {func | _ = compartment["functions"][func]}
+    symbols == required
+}
+
+only_required_disabled_interrupts_present {
+    every compartment in required_disabled_interrupts {
+        compartment_only_required_disabled_interrupts(compartment)
+    }
+}
+
+default valid := false
+valid {
+    all_required_compartments_present
+    only_required_disabled_interrupts_present
+}

--- a/exercises/firmware_auditing/part_3/malloc1024.cc
+++ b/exercises/firmware_auditing/part_3/malloc1024.cc
@@ -1,0 +1,19 @@
+// Copyright lowRISC Contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+#define MALLOC_QUOTA 1024 // Quota of 1 KiB
+
+#include <compartment.h>
+
+/// Thread entry point.
+[[noreturn]] void __cheri_compartment("malloc1024") entry_point()
+{
+	void *mem = malloc(1024 * sizeof(char));
+	free(mem);
+
+	int x = 0;
+	while (true)
+	{
+		x = x + 1;
+	};
+}

--- a/exercises/firmware_auditing/part_3/malloc2048.cc
+++ b/exercises/firmware_auditing/part_3/malloc2048.cc
@@ -1,0 +1,19 @@
+// Copyright lowRISC Contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+#define MALLOC_QUOTA 2048 // Quota of 2 KiB
+
+#include <compartment.h>
+
+/// Thread entry point.
+[[noreturn]] void __cheri_compartment("malloc2048") entry_point()
+{
+	void *mem = malloc(2048 * sizeof(char));
+	free(mem);
+
+	int x = 0;
+	while (true)
+	{
+		x = x + 1;
+	};
+}

--- a/exercises/firmware_auditing/part_3/malloc4096.cc
+++ b/exercises/firmware_auditing/part_3/malloc4096.cc
@@ -1,0 +1,19 @@
+// Copyright lowRISC Contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+#define MALLOC_QUOTA 4096 // Quota of 4 KiB
+
+#include <compartment.h>
+
+/// Thread entry point.
+[[noreturn]] void __cheri_compartment("malloc4096") entry_point()
+{
+	void *mem = malloc(4096 * sizeof(char));
+	free(mem);
+
+	int x = 0;
+	while (true)
+	{
+		x = x + 1;
+	};
+}

--- a/exercises/firmware_auditing/part_3/malloc_check.rego
+++ b/exercises/firmware_auditing/part_3/malloc_check.rego
@@ -1,0 +1,51 @@
+# Copyright lowRISC Contributors.
+# SPDX-License-Identifier: Apache-2.0
+package malloc_check
+
+import future.keywords
+
+allocator_capabilities := [
+    {"owner": owner, "capability": data.rtos.decode_allocator_capability(cap)} |
+    cap = input.compartments[owner].imports[_] ;
+    data.rtos.is_allocator_capability(cap)
+]
+
+all_allocations_leq(limit) {
+    every cap in allocator_capabilities {
+        cap.capability.quota <= limit
+    }
+}
+
+unique_allocator_compartments contains owner if {
+    some {"owner": owner} in allocator_capabilities
+}
+
+total_quota_per_compartment[owner] = quota if {
+    some owner in unique_allocator_compartments
+    quota := sum([cap.capability.quota | cap = allocator_capabilities[_]; cap.owner == owner])
+}
+
+all_compartments_allocate_leq(limit) {
+    some quotas
+    quotas = [ quota | quota = total_quota_per_compartment[_] ]
+    every quota in quotas {
+        quota <= limit
+    }
+}
+
+total_quota := sum([cap.capability.quota | cap = allocator_capabilities[_]])
+
+total_allocation_leq(limit) {
+    total_quota <= limit
+}
+
+default valid := false
+valid {
+    data.rtos.all_sealed_allocator_capabilities_are_valid
+    # No individual allocation should be able to allocate more than 20 KiB at one time
+    all_allocations_leq(20480)
+    # No individual compartment should be able to allocate more than 40 KiB simultaneously
+    all_compartments_allocate_leq(40960)
+    # The entire firmware image cannot allocate more than 100 KiB simultaneously
+    total_allocation_leq(102400)
+}

--- a/exercises/firmware_auditing/part_3/malloc_many.cc
+++ b/exercises/firmware_auditing/part_3/malloc_many.cc
@@ -1,0 +1,58 @@
+// Copyright lowRISC Contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+#define MALLOC_QUOTA 1024 // Quota of 1 KiB
+
+#include <compartment.h>
+
+DECLARE_AND_DEFINE_ALLOCATOR_CAPABILITY(__second_malloc_capability,
+                                        MALLOC_QUOTA * 2)
+DECLARE_AND_DEFINE_ALLOCATOR_CAPABILITY(__third_malloc_capability,
+                                        MALLOC_QUOTA * 4)
+DECLARE_AND_DEFINE_ALLOCATOR_CAPABILITY(__fourth_malloc_capability,
+                                        MALLOC_QUOTA * 8)
+DECLARE_AND_DEFINE_ALLOCATOR_CAPABILITY(__fifth_malloc_capability,
+                                        MALLOC_QUOTA * 16)
+#define MALLOC_CAPABILITY_2 STATIC_SEALED_VALUE(__second_malloc_capability)
+#define MALLOC_CAPABILITY_3 STATIC_SEALED_VALUE(__third_malloc_capability)
+#define MALLOC_CAPABILITY_4 STATIC_SEALED_VALUE(__fourth_malloc_capability)
+#define MALLOC_CAPABILITY_5 STATIC_SEALED_VALUE(__fifth_malloc_capability)
+
+#define MALLOC_WITH_CAPABILITY_FUNC(name, malloc_num)                          \
+	static inline void *malloc##malloc_num(size_t size)                        \
+	{                                                                          \
+		Timeout t = {0, MALLOC_WAIT_TICKS};                                    \
+		void   *ptr =                                                          \
+		  heap_allocate(&t, name, size, AllocateWaitRevocationNeeded);         \
+		if (!__builtin_cheri_tag_get(ptr))                                     \
+		{                                                                      \
+			ptr = NULL;                                                        \
+		}                                                                      \
+		return ptr;                                                            \
+	}
+
+MALLOC_WITH_CAPABILITY_FUNC(MALLOC_CAPABILITY_2, 2)
+MALLOC_WITH_CAPABILITY_FUNC(MALLOC_CAPABILITY_3, 3)
+MALLOC_WITH_CAPABILITY_FUNC(MALLOC_CAPABILITY_4, 4)
+MALLOC_WITH_CAPABILITY_FUNC(MALLOC_CAPABILITY_5, 5)
+
+/// Thread entry point.
+[[noreturn]] void __cheri_compartment("malloc_many") entry_point()
+{
+	void *mem = malloc(MALLOC_QUOTA * sizeof(char));
+	free(mem);
+	void *mem2 = malloc2(MALLOC_QUOTA * 2 * sizeof(char));
+	free(mem2);
+	void *mem3 = malloc3(MALLOC_QUOTA * 4 * sizeof(char));
+	free(mem3);
+	void *mem4 = malloc4(MALLOC_QUOTA * 8 * sizeof(char));
+	free(mem4);
+	void *mem5 = malloc5(MALLOC_QUOTA * 16 * sizeof(char));
+	free(mem5);
+
+	int x = 0;
+	while (true)
+	{
+		x = x + 1;
+	};
+}

--- a/exercises/firmware_auditing/xmake.lua
+++ b/exercises/firmware_auditing/xmake.lua
@@ -20,3 +20,32 @@ firmware("firmware_auditing_part_1")
         }, {expand = false})
     end)
     after_link(convert_to_uf2)
+
+-- Part 2
+compartment("disable_interrupts")
+    add_files("part_2/disable_interrupts.cc")
+
+compartment("bad_disable_interrupts")
+    add_files("part_2/bad_disable_interrupts.cc")
+
+firmware("firmware_auditing_part_2")
+    add_deps("freestanding", "disable_interrupts", "bad_disable_interrupts")
+    on_load(function(target)
+        target:values_set("board", "$(board)")
+        target:values_set("threads", {
+            {
+                compartment = "disable_interrupts",
+                priority = 1,
+                entry_point = "entry_point",
+                stack_size = 0x200,
+                trusted_stack_frames = 1
+            }, {
+                compartment = "bad_disable_interrupts",
+                priority = 2,
+                entry_point = "entry_point",
+                stack_size = 0x200,
+                trusted_stack_frames = 1
+            }
+        }, {expand = false})
+    end)
+    after_link(convert_to_uf2)

--- a/exercises/firmware_auditing/xmake.lua
+++ b/exercises/firmware_auditing/xmake.lua
@@ -49,3 +49,50 @@ firmware("firmware_auditing_part_2")
         }, {expand = false})
     end)
     after_link(convert_to_uf2)
+
+-- Part 3
+compartment("malloc1024")
+    add_files("part_3/malloc1024.cc")
+
+compartment("malloc2048")
+    add_files("part_3/malloc2048.cc")
+
+compartment("malloc4096")
+    add_files("part_3/malloc4096.cc")
+
+compartment("malloc_many")
+    add_files("part_3/malloc_many.cc")
+
+firmware("firmware_auditing_part_3")
+    add_deps("freestanding", "malloc1024", "malloc2048", "malloc4096", "malloc_many")
+    on_load(function(target)
+        target:values_set("board", "$(board)")
+        target:values_set("threads", {
+            {
+                compartment = "malloc1024",
+                priority = 4,
+                entry_point = "entry_point",
+                stack_size = 0x200,
+                trusted_stack_frames = 2
+            }, {
+                compartment = "malloc2048",
+                priority = 3,
+                entry_point = "entry_point",
+                stack_size = 0x200,
+                trusted_stack_frames = 2
+            }, {
+                compartment = "malloc4096",
+                priority = 2,
+                entry_point = "entry_point",
+                stack_size = 0x200,
+                trusted_stack_frames = 2
+            }, {
+                compartment = "malloc_many",
+                priority = 1,
+                entry_point = "entry_point",
+                stack_size = 0x200,
+                trusted_stack_frames = 2
+            }
+        }, {expand = false})
+    end)
+    after_link(convert_to_uf2)

--- a/exercises/firmware_auditing/xmake.lua
+++ b/exercises/firmware_auditing/xmake.lua
@@ -1,0 +1,22 @@
+-- Copyright lowRISC Contributors.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Part 1
+compartment("sealed_capability")
+    add_files("part_1/sealed_capability.cc")
+
+firmware("firmware_auditing_part_1")
+    add_deps("freestanding", "sealed_capability")
+    on_load(function(target)
+        target:values_set("board", "$(board)")
+        target:values_set("threads", {
+            {
+                compartment = "sealed_capability",
+                priority = 2,
+                entry_point = "do_things",
+                stack_size = 0x200,
+                trusted_stack_frames = 1
+            },
+        }, {expand = false})
+    end)
+    after_link(convert_to_uf2)

--- a/exercises/xmake.lua
+++ b/exercises/xmake.lua
@@ -13,4 +13,4 @@ includes("../common.lua")
 option("board")
     set_default("sonata-prerelease")
 
-includes("hardware_access_control")
+includes("hardware_access_control", "firmware_auditing")


### PR DESCRIPTION
This PR adds documentation/exercises for `cheriot-audit` and OPA Rego (the language it uses).

A short documentation page on auditing firmware is introduced - this primarily provides a link to documentation sources (for CHERIoT Audit and Rego), an introduction to what CHERIoT Audit is used for, a guide to setting up and using `cheriot-audit`, as well as some basic recommendations for Rego development.

3 self-contained exercises are then introduced, alongside a quick introduction/primer explaining some basic concepts/syntax in Rego to enable readers to follow the exercises. The exercises are as follows:
1. **Exercise 1**: follows a policy for checking that sealed capabilities are not used inside firmware, and for inspecting these capabilities. This is intended to be a shorter example to introduce the syntax and use of Rego and CHERIoT Audit.
2. **Exercise 2**: follows a policy for checking that only specific functions run with interrupts disabled. This is intended to be a far more practical and useful longer example which introduces more of Rego's features. It also introduces a built-in function from CHERIoT Audit to motivate readers to check for existing built-in functionality.
3. **Exercise 3**: follows a policy for checking that heap allocation limits are followed by firmware. This is again intended to be a more practical and useful longer example.

Note that this PR is made based on my understanding of CHERIoT Audit / Rego solely from some initial experimentation and developing these three exercises. As such, there may be some instances where wording is not entirely accurate or best practices are not being followed. I have mainly focused on creating and documenting some working examples, to be able to showcase what kind of things are possible when auditing firmware.