### PR TITLE
Minor fixes to the i2c_example code

### DIFF
--- a/examples/all/i2c_example.cc
+++ b/examples/all/i2c_example.cc
@@ -22,8 +22,8 @@ static void read_temperature_sensor_value(Mmio<OpenTitanI2c> i2c,
 	i2c->blocking_write(0x48, buf, 1, false);
 	if (i2c->blocking_read(0x48, buf, 2u))
 	{
-		uint16_t temp = (buf[0] << 8) | buf[1];
-		Debug::log("The {} readout is {}", regName, temp);
+		int64_t temp = ((buf[0] << 8) | buf[1]) * 1000000LL / 128;
+		Debug::log("The {} readout is {} microdegrees", regName, temp);
 	}
 	else
 	{

--- a/examples/all/i2c_example.cc
+++ b/examples/all/i2c_example.cc
@@ -22,7 +22,8 @@ static void read_temperature_sensor_value(Mmio<OpenTitanI2c> i2c,
 	i2c->blocking_write(0x48, buf, 1, false);
 	if (i2c->blocking_read(0x48, buf, 2u))
 	{
-		int64_t temp = ((buf[0] << 8) | buf[1]) * 1000000LL / 128;
+        int16_t rawTemp = (buf[0] << 8) | buf[1];
+        int64_t temp = rawTemp * 1000000LL / 128;
 		Debug::log("The {} readout is {} microdegrees", regName, temp);
 	}
 	else

--- a/examples/all/i2c_example.cc
+++ b/examples/all/i2c_example.cc
@@ -22,8 +22,8 @@ static void read_temperature_sensor_value(Mmio<OpenTitanI2c> i2c,
 	i2c->blocking_write(0x48, buf, 1, false);
 	if (i2c->blocking_read(0x48, buf, 2u))
 	{
-        int16_t rawTemp = (buf[0] << 8) | buf[1];
-        int64_t temp = rawTemp * 1000000LL / 128;
+		int16_t rawTemp = (buf[0] << 8) | buf[1];
+		int64_t temp = rawTemp * 1000000LL / 128;
 		Debug::log("The {} readout is {} microdegrees", regName, temp);
 	}
 	else

--- a/examples/all/i2c_example.cc
+++ b/examples/all/i2c_example.cc
@@ -77,10 +77,10 @@ static void id_eeprom_report(Mmio<OpenTitanI2c> i2c, const uint8_t IdAddr)
 
 	id_eeprom_report(i2c0, 0x50);
 
-	read_temperature_sensor_value(i2c1, "temporature sensor configuration", 1);
+	read_temperature_sensor_value(i2c1, "temperature sensor configuration", 1);
 	while (true)
 	{
-		read_temperature_sensor_value(i2c1, "temporature", 0);
+		read_temperature_sensor_value(i2c1, "temperature", 0);
 		thread_millisecond_wait(4000);
 	}
 }


### PR DESCRIPTION
2 commits to examples/all/i2c_example.cc. Minor spelling mistake fix on lines 80 and 83. Update of calculation on line 25 to return the correct temperature in micro-Celsius. 