### PR TITLE
Removed legacy toolchain from default devshell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
         run: |
           nix build -L .?submodules=1#sonata-exercises
           nix build -L .?submodules=1#sonata-examples
+          nix build -L .?submodules=1#sonata-automotive-demo-legacy-component
           nix build -L .?submodules=1#sonata-tests
 
       - name: Run Nix Checks

--- a/examples/automotive/README.md
+++ b/examples/automotive/README.md
@@ -32,3 +32,13 @@ The demo does feature different applications which can run with varying
 amounts of hardware availability, as detailed in the library documentation,
 but the minimum requirement is at least the two boards and the connecting
 Ethernet cable.
+
+## Building
+
+The cheriot componenents of this demo are built along with the rest of the examples.
+However, the legacy component needs to be build seperately.
+
+```sh
+xmake -P examples
+xmake -P examples/automotive/legacy/
+```

--- a/examples/automotive/xmake.lua
+++ b/examples/automotive/xmake.lua
@@ -1,4 +1,4 @@
 -- Copyright lowRISC Contributors.
 -- SPDX-License-Identifier: Apache-2.0
 
-includes("cheri", "legacy")
+includes("cheri")

--- a/flake.nix
+++ b/flake.nix
@@ -173,7 +173,6 @@
             ++ [
               lrPkgs.uf2conv
               lrPkgs.cheriot-audit
-              lrPkgs.lowrisc-toolchain-gcc-rv32imcb
               pkgs.python3Packages.pyserial
               mdutilsPkgs.default
             ];
@@ -182,6 +181,10 @@
           name = "sonata-sw-with-sim";
           packages = [sonataSystemPkgs.sonata-simulator] ++ default.nativeBuildInputs;
           SONATA_SIM_BOOT_STUB = "${sonataSystemPkgs.sonata-sim-boot-stub.out}/share/sim_boot_stub";
+        };
+        env-with-everything = pkgs.mkShell {
+          name = "sonata-sw-with-everything";
+          packages = env-with-sim.nativeBuildInputs ++ [lrPkgs.lowrisc-toolchain-gcc-rv32imcb];
         };
       };
       packages = {inherit sonata-exercises sonata-examples sonata-tests sonata-software-documentation;};

--- a/flake.nix
+++ b/flake.nix
@@ -27,8 +27,6 @@
     mdutils,
   }: let
     system_outputs = system: let
-      version = "0.0.1";
-
       pkgs = import nixpkgs {inherit system;};
       lrPkgs = lowrisc-nix.outputs.packages.${system};
       mdutilsPkgs = mdutils.outputs.packages.${system};
@@ -63,7 +61,7 @@
       };
 
       sonata-software-documentation = lrDoc.buildMdbookSite {
-        inherit version;
+        version = "";
         pname = "sonata-software-documentation";
         src = fileset.toSource {
           root = ./.;

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,21 @@
         dontFixup = true;
       };
 
+      sonata-automotive-demo-legacy-component = pkgs.stdenvNoCC.mkDerivation {
+        name = "sonata-automotive-demo-legacy-component";
+        src = fileset.toSource {
+          root = ./.;
+          fileset = fileset.unions [./examples/automotive ./third_party];
+        };
+        buildInputs = with lrPkgs; [xmake lowrisc-toolchain-gcc-rv32imcb];
+        buildPhase = "xmake -P ./examples/automotive/legacy/";
+        installPhase = ''
+          mkdir -p $out/share/
+          cp build/ilp32/rv32imc/release/automotive_demo_send_legacy $out/share
+        '';
+        dontFixup = true;
+      };
+
       sonata-software-documentation = lrDoc.buildMdbookSite {
         inherit version;
         pname = "sonata-software-documentation";
@@ -182,7 +197,15 @@
           packages = env-with-sim.nativeBuildInputs ++ [lrPkgs.lowrisc-toolchain-gcc-rv32imcb];
         };
       };
-      packages = {inherit sonata-exercises sonata-examples sonata-tests sonata-software-documentation;};
+      packages = {
+        inherit
+          sonata-exercises
+          sonata-examples
+          sonata-tests
+          sonata-software-documentation
+          sonata-automotive-demo-legacy-component
+          ;
+      };
       checks = {inherit tests-simulator;};
       apps = builtins.listToAttrs (map (program: {
         inherit (program) name;

--- a/flake.nix
+++ b/flake.nix
@@ -39,12 +39,7 @@
       inherit (pkgs.lib) fileset getExe;
 
       commonSoftwareBuildAttributes = {
-        buildInputs =
-          cheriotPkgs
-          ++ [
-            lrPkgs.uf2conv
-            lrPkgs.lowrisc-toolchain-gcc-rv32imcb
-          ];
+        buildInputs = cheriotPkgs ++ [lrPkgs.uf2conv];
         installPhase = ''
           mkdir -p $out/share/
           cp build/cheriot/cheriot/release/* $out/share/


### PR DESCRIPTION
The lowrisc-nix legacy toolchain only supports linux so removed it from the default environment so macos users can use default environment. Made a new `env-with-everything` environment that includes everything (and therefore only supports linux).

legacy toolchain added in https://github.com/lowRISC/sonata-software/commit/12c4b697aee2be3cb0bf2d6e700fe27391786eac#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0L41