### PR TITLE
Update example software and exercises for 1.0 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ name: CI
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "staging"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "staging"]
 
 # Cancel existing runs if a pull request is pushed.
 # For branch pushes, this will queue a new run and cancel the existing one. This allows the cache

--- a/examples/all/i2c_example.cc
+++ b/examples/all/i2c_example.cc
@@ -33,6 +33,7 @@ static void read_temperature_sensor_value(Mmio<OpenTitanI2c> i2c,
 	else
 	{
 		Debug::log("Could not read the {}", regName);
+		return;
 	}
 }
 
@@ -52,6 +53,7 @@ static void id_eeprom_report(Mmio<OpenTitanI2c> i2c, const uint8_t IdAddr)
 	if (!i2c->blocking_read(IdAddr, data, sizeof(data)))
 	{
 		Debug::log("Failed to read EEPROM ID of device at address {}", IdAddr);
+		return;
 	}
 
 	Debug::log("EEPROM ID of device at address {}:", IdAddr);

--- a/examples/all/i2c_example.cc
+++ b/examples/all/i2c_example.cc
@@ -19,7 +19,11 @@ static void read_temperature_sensor_value(Mmio<OpenTitanI2c> i2c,
                                           const uint8_t      RegIdx)
 {
 	uint8_t buf[2] = {RegIdx, 0};
-	i2c->blocking_write(0x48, buf, 1, false);
+	if (!i2c->blocking_write(0x48, buf, 1, false))
+	{
+		Debug::log("Could not write the {} address", regName);
+		return;
+	}
 	if (i2c->blocking_read(0x48, buf, 2u))
 	{
 		int16_t regValue = static_cast<int16_t>((buf[0] << 8) | buf[1]);
@@ -35,7 +39,11 @@ static void read_temperature_sensor_value(Mmio<OpenTitanI2c> i2c,
 static void id_eeprom_report(Mmio<OpenTitanI2c> i2c, const uint8_t IdAddr)
 {
 	uint8_t addr[2] = {0};
-	i2c->blocking_write(0x50u, addr, 2, true);
+	if (!i2c->blocking_write(0x50u, addr, 2, true))
+	{
+		Debug::log("Could not write the ID EEPROM address");
+		return;
+	}
 
 	static uint8_t data[0x80];
 	// Initialize the buffer to known contents in case of read issues.

--- a/examples/all/led_walk_raw.cc
+++ b/examples/all/led_walk_raw.cc
@@ -16,7 +16,7 @@ void __cheri_compartment("led_walk_raw") start_walking()
 {
 	Debug::log("Look pretty LEDs!");
 
-	auto gpio = MMIO_CAPABILITY(SonataGPIO, gpio);
+	auto gpio = MMIO_CAPABILITY(SonataGpioBoard, gpio_board);
 
 	int  count    = 0;
 	bool switchOn = true;

--- a/examples/all/proximity_sensor_example.cc
+++ b/examples/all/proximity_sensor_example.cc
@@ -85,6 +85,7 @@ static void setup_proximity_sensor(Mmio<OpenTitanI2c> i2c, const uint8_t Addr)
 	if (!i2c->blocking_write(ApdS9960I2cAddress, buf, 2, true))
 	{
 		Debug::log("Failed to write proximity sensor address");
+		return;
 	}
 }
 

--- a/examples/all/proximity_sensor_example.cc
+++ b/examples/all/proximity_sensor_example.cc
@@ -32,7 +32,11 @@ static void setup_proximity_sensor(Mmio<OpenTitanI2c> i2c, const uint8_t Addr)
 
 	buf[0] = ApdS9960Id;
 
-	i2c->blocking_write(ApdS9960I2cAddress, buf, 1, false);
+	if (!i2c->blocking_write(ApdS9960I2cAddress, buf, 1, false))
+	{
+		Debug::log("Failed to write proximity sensor address");
+		return;
+	}
 	bool success = i2c->blocking_read(ApdS9960I2cAddress, buf, 1);
 	Debug::Assert(success, "Failed to read proximity sensor ID");
 
@@ -46,27 +50,42 @@ static void setup_proximity_sensor(Mmio<OpenTitanI2c> i2c, const uint8_t Addr)
 	// Disable everything
 	buf[0] = ApdS9960Enable;
 	buf[1] = 0x0;
-	i2c->blocking_write(ApdS9960I2cAddress, buf, 2, true);
+	if (!i2c->blocking_write(ApdS9960I2cAddress, buf, 2, true))
+	{
+		Debug::log("Failed to write proximity sensor address");
+		return;
+	}
 	// Wait for all engines to go idle
 	thread_millisecond_wait(25);
 
 	// Set PEN (proximity enable) and PON (power on)
 	buf[0] = ApdS9960Enable;
 	buf[1] = 0x5;
-	i2c->blocking_write(ApdS9960I2cAddress, buf, 2, true);
+	if (!i2c->blocking_write(ApdS9960I2cAddress, buf, 2, true))
+	{
+		Debug::log("Failed to write proximity sensor address");
+		return;
+	}
 	// Wait for power on
 	thread_millisecond_wait(10);
 
 	// Set proximity gain to 8x
 	buf[0] = ApdS9960CR1;
 	buf[1] = 0x0c;
-	i2c->blocking_write(ApdS9960I2cAddress, buf, 2, true);
+	if (!i2c->blocking_write(ApdS9960I2cAddress, buf, 2, true))
+	{
+		Debug::log("Failed to write proximity sensor address");
+		return;
+	}
 
 	// Set proximity pulse length to 4us and pulse count to 16us
 	// (experimentially determined, other values may work better!)
 	buf[0] = ApdS9960Ppc;
 	buf[1] = 0x04;
-	i2c->blocking_write(ApdS9960I2cAddress, buf, 2, true);
+	if (!i2c->blocking_write(ApdS9960I2cAddress, buf, 2, true))
+	{
+		Debug::log("Failed to write proximity sensor address");
+	}
 }
 
 static uint8_t read_proximity_sensor(Mmio<OpenTitanI2c> i2c)
@@ -74,7 +93,11 @@ static uint8_t read_proximity_sensor(Mmio<OpenTitanI2c> i2c)
 	uint8_t buf[1];
 
 	buf[0] = ApdS9960Pdata;
-	i2c->blocking_write(ApdS9960I2cAddress, buf, 1, false);
+	if (!i2c->blocking_write(ApdS9960I2cAddress, buf, 1, false))
+	{
+		Debug::log("Failed to write proximity sensor address");
+		return 0;
+	}
 	if (!i2c->blocking_read(ApdS9960I2cAddress, buf, 1))
 	{
 		Debug::log("Failed to read proximity sensor value");

--- a/examples/automotive/README.md
+++ b/examples/automotive/README.md
@@ -6,6 +6,9 @@ SPDX-License-Identifier: Apache-2.0
 
 ## Description
 
+**Note: this demo is currently not updated for the latest 1.0 hardware changes,
+and as such will not work.**
+
 The Sonata automotive demo is a demo designed around an automotive context,
 which is run in two different environments - one on the Sonata board running
 CHERIoT RTOS with CHERIoT enabled, and another running baremetal on Sonata

--- a/examples/automotive/cheri/receive.cc
+++ b/examples/automotive/cheri/receive.cc
@@ -4,6 +4,7 @@
 #include <compartment.h>
 #include <debug.hh>
 #include <platform-ethernet.hh>
+#include <platform-gpio.hh>
 #include <platform-pwm.hh>
 #include <thread.h>
 
@@ -13,8 +14,7 @@
 
 #include "common.hh"
 
-using Debug     = ConditionalDebug<true, "Automotive-Receive">;
-using SonataPwm = SonataPulseWidthModulation;
+using Debug = ConditionalDebug<true, "Automotive-Receive">;
 using namespace CHERI;
 using namespace sonata::lcd;
 
@@ -63,9 +63,9 @@ struct CarInfo
 };
 
 // Driver structs/classes
-EthernetDevice      *ethernet;
-SonataLcd           *lcd;
-volatile SonataGPIO *gpio;
+EthernetDevice           *ethernet;
+SonataLcd                *lcd;
+volatile SonataGpioBoard *gpio;
 
 // Sets the operating mode that the demo is running in. Default is passthrough.
 DemoMode operatingMode = DemoModePassthrough;
@@ -505,7 +505,7 @@ void update_demo_simulation(CarInfo *carInfo, Point centre)
 	// Initialise the LCD & GPIO drivers
 	lcd = new SonataLcd();
 	lcd->clean(BACKGROUND_COLOUR);
-	gpio = MMIO_CAPABILITY(SonataGPIO, gpio);
+	gpio = MMIO_CAPABILITY(SonataGpioBoard, gpio_board);
 
 	// Start the main loop
 	main_demo_loop();

--- a/examples/automotive/cheri/send.cc
+++ b/examples/automotive/cheri/send.cc
@@ -5,6 +5,7 @@
 #include <debug.hh>
 #include <platform-adc.hh>
 #include <platform-ethernet.hh>
+#include <platform-gpio.hh>
 #include <thread.h>
 
 #include "../../../libraries/lcd.hh"
@@ -282,7 +283,7 @@ void lcd_draw_img(uint32_t       x,
  */
 uint8_t read_joystick()
 {
-	auto gpio = MMIO_CAPABILITY(SonataGPIO, gpio);
+	auto gpio = MMIO_CAPABILITY(SonataGpioBoard, gpio_board);
 	return static_cast<uint8_t>(gpio->read_joystick());
 }
 
@@ -294,7 +295,7 @@ uint8_t read_joystick()
  */
 bool read_pedal_digital()
 {
-	auto gpio = MMIO_CAPABILITY(SonataGPIO, gpio);
+	auto gpio = MMIO_CAPABILITY(SonataGpioBoard, gpio_board);
 	return (gpio->input & (1 << 13)) > 0;
 }
 

--- a/examples/snake/snake.cc
+++ b/examples/snake/snake.cc
@@ -148,7 +148,7 @@ class SnakeGame
 	 * @param gpio The Sonata GPIO driver to use for I/O operations.
 	 * @param lcd The LCD that will be drawn to.
 	 */
-	void wait_for_start(volatile SonataGPIO *gpio, SonataLcd *lcd)
+	void wait_for_start(volatile SonataGpioBoard *gpio, SonataLcd *lcd)
 	{
 		Size  displaySize = lcd->resolution();
 		Point centre      = {displaySize.width / 2, displaySize.height / 2};
@@ -224,8 +224,8 @@ class SnakeGame
 	bool joystick_in_direction(SonataJoystick joystick,
 	                           SonataJoystick direction)
 	{
-		return (static_cast<uint8_t>(joystick) &
-		        static_cast<uint8_t>(direction)) > 0;
+		return (static_cast<uint16_t>(joystick) &
+		        static_cast<uint16_t>(direction)) > 0;
 	};
 
 	/**
@@ -235,7 +235,7 @@ class SnakeGame
 	 *
 	 * @param gpio The Sonata GPIO driver to use for I/O operations.
 	 */
-	Direction read_joystick(volatile SonataGPIO *gpio)
+	Direction read_joystick(volatile SonataGpioBoard *gpio)
 	{
 		SonataJoystick joystickState = gpio->read_joystick();
 		// The joystick can be in many possible directions - we check directions
@@ -282,7 +282,7 @@ class SnakeGame
 	 * @param milliseconds The time to wait for in milliseconds.
 	 * @param gpio The Sonata GPIO driver to use for I/O operations.
 	 */
-	void wait_with_input(uint32_t milliseconds, volatile SonataGPIO *gpio)
+	void wait_with_input(uint32_t milliseconds, volatile SonataGpioBoard *gpio)
 	{
 		const uint32_t CyclesPerMillisecond = CPU_TIMER_HZ / 1000;
 		const uint32_t Cycles  = milliseconds * CyclesPerMillisecond;
@@ -461,7 +461,7 @@ class SnakeGame
 	 * @param position The integer tile position (x, y) to draw at.
 	 * @return true if the game is still active, false if the game is over.
 	 */
-	bool update_game_state(volatile SonataGPIO *gpio, SonataLcd *lcd)
+	bool update_game_state(volatile SonataGpioBoard *gpio, SonataLcd *lcd)
 	{
 		currentDirection = read_joystick(gpio);
 
@@ -525,7 +525,7 @@ class SnakeGame
 	 * @param gpio The Sonata GPIO driver to use for I/O operations
 	 * @param lcd The LCD that will be drawn to.
 	 */
-	void main_game_loop(volatile SonataGPIO *gpio, SonataLcd *lcd)
+	void main_game_loop(volatile SonataGpioBoard *gpio, SonataLcd *lcd)
 	{
 		const uint32_t CyclesPerMillisecond = CPU_TIMER_HZ / 1000;
 		uint64_t       currentTime          = rdcycle64();
@@ -581,7 +581,7 @@ class SnakeGame
 	 * @param gpio The Sonata GPIO driver to use for I/O operations.
 	 * @param lcd The LCD that will be drawn to.
 	 */
-	void run_game(volatile SonataGPIO *gpio, SonataLcd *lcd)
+	void run_game(volatile SonataGpioBoard *gpio, SonataLcd *lcd)
 	{
 		wait_for_start(gpio, lcd);
 		initialise_game();
@@ -650,7 +650,7 @@ compartment_error_handler(ErrorState *frame, size_t mcause, size_t mtval)
 // Thread entry point.
 void __cheri_compartment("snake") snake()
 {
-	auto gpio = MMIO_CAPABILITY(SonataGPIO, gpio);
+	auto gpio = MMIO_CAPABILITY(SonataGpioBoard, gpio_board);
 	auto lcd  = SonataLcd();
 	Debug::log("Detected display resolution: {} {}",
 	           static_cast<int>(lcd.resolution().width),

--- a/exercises/firmware_auditing/part_1/sealed_capability.cc
+++ b/exercises/firmware_auditing/part_1/sealed_capability.cc
@@ -10,7 +10,7 @@ static constexpr size_t   ArrSize = 32;
 
 void __cheri_compartment("sealed_capability") do_things()
 {
-	auto gpio = MMIO_CAPABILITY(SonataGPIO, gpio);
+	auto gpio = MMIO_CAPABILITY(SonataGpioBoard, gpio_board);
 
 	uint32_t arr[ArrSize];
 	// Comment the above line and uncomment the below line to allocate on the

--- a/exercises/hardware_access_control/README.md
+++ b/exercises/hardware_access_control/README.md
@@ -25,7 +25,7 @@ The sources of these compartments can be found in [`exercises/hardware_access_co
 
 Let's look inside `blinky_raw`.
 It uses the RTOS' `MMIO_CAPABILITY` macro to get the capability that grants it access to the GPIO MMIO region.
-This magic macro will handle adding the MMIO region to the compartment's imports and mapping it to a type, in this case `SonataGPIO` (from [`platform-gpio.hh`][]).
+This magic macro will handle adding the MMIO region to the compartment's imports and mapping it to a type, in this case `SonataGpioBoard` (from [`platform-gpio.hh`][]).
 *For more information on this macro, see [the drivers section of CHERIoT programmers guide][].*
 
 [the drivers section of CHERIoT programmers guide]: https://cheriot.org/book/top-drivers-top.html#mmio_capabilities
@@ -154,7 +154,7 @@ One can browse the other functions available as part of the compartment package 
 ## Part ∞
 
 Where to go from here...
-- There are input devices available through `SonataGPIO`.
+- There are input devices available through `SonataGpioBoard`.
     You could have a go at adding these to the `gpio_access` compartment.
 - The interactions with `ledTaken` global in the `gpio_access` compartment aren't thread safe.
     You could take a look at `cheriot-rtos/examples/06.producer-consumer/` to learn how to use a futex to make it thread safe.

--- a/exercises/hardware_access_control/part_1/blinky_raw.cc
+++ b/exercises/hardware_access_control/part_1/blinky_raw.cc
@@ -14,7 +14,7 @@ void __cheri_compartment("blinky_raw") start_blinking()
 {
 	Debug::log("Look a blinking LED!");
 
-	auto gpio = MMIO_CAPABILITY(SonataGPIO, gpio);
+	auto gpio = MMIO_CAPABILITY(SonataGpioBoard, gpio_board);
 
 	while (true)
 	{

--- a/exercises/hardware_access_control/part_1/led_walk_raw.cc
+++ b/exercises/hardware_access_control/part_1/led_walk_raw.cc
@@ -14,7 +14,7 @@ void __cheri_compartment("led_walk_raw") start_walking()
 {
 	Debug::log("Look walking LEDs!");
 
-	auto gpio = MMIO_CAPABILITY(SonataGPIO, gpio);
+	auto gpio = MMIO_CAPABILITY(SonataGpioBoard, gpio_board);
 
 	size_t ledIdx = NumLeds - 1;
 	while (true)

--- a/exercises/hardware_access_control/part_2/gpio_access.cc
+++ b/exercises/hardware_access_control/part_2/gpio_access.cc
@@ -33,7 +33,7 @@ static auto key()
  */
 static auto gpio()
 {
-	static auto gpio = MMIO_CAPABILITY(SonataGPIO, gpio);
+	static auto gpio = MMIO_CAPABILITY(SonataGpioBoard, gpio_board);
 	return gpio;
 }
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,247 @@
 {
   "nodes": {
+    "attic": {
+      "inputs": {
+        "crane": "crane",
+        "flake-compat": "flake-compat",
+        "flake-utils": [
+          "sonata-system",
+          "lowrisc-it",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "sonata-system",
+          "lowrisc-it",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": [
+          "sonata-system",
+          "lowrisc-it",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1717279440,
+        "narHash": "sha256-kH04ReTjxOpQumgWnqy40vvQLSnLGxWP6RF3nq5Esrk=",
+        "owner": "zhaofengli",
+        "repo": "attic",
+        "rev": "717cc95983cdc357bc347d70be20ced21f935843",
+        "type": "github"
+      },
+      "original": {
+        "owner": "zhaofengli",
+        "repo": "attic",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "inputs": {
+        "nixpkgs": [
+          "sonata-system",
+          "lowrisc-it",
+          "attic",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1717025063,
+        "narHash": "sha256-dIubLa56W9sNNz0e8jGxrX3CAkPXsq7snuFA/Ie6dn8=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "480dff0be03dac0e51a8dfc26e882b0d123a450e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "crane_2": {
+      "inputs": {
+        "flake-compat": [
+          "sonata-system",
+          "lowrisc-it",
+          "lanzaboote",
+          "flake-compat"
+        ],
+        "flake-utils": [
+          "sonata-system",
+          "lowrisc-it",
+          "lanzaboote",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "sonata-system",
+          "lowrisc-it",
+          "lanzaboote",
+          "nixpkgs"
+        ],
+        "rust-overlay": [
+          "sonata-system",
+          "lowrisc-it",
+          "lanzaboote",
+          "rust-overlay"
+        ]
+      },
+      "locked": {
+        "lastModified": 1681177078,
+        "narHash": "sha256-ZNIjBDou2GOabcpctiQykEQVkI8BDwk7TyvlWlI4myE=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "0c9f468ff00576577d83f5019a66c557ede5acf6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "deploy-rs": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "nixpkgs": [
+          "sonata-system",
+          "lowrisc-it",
+          "nixpkgs"
+        ],
+        "utils": [
+          "sonata-system",
+          "lowrisc-it",
+          "flake-utils"
+        ]
+      },
+      "locked": {
+        "lastModified": 1715699772,
+        "narHash": "sha256-sKhqIgucN5sI/7UQgBwsonzR4fONjfMr9OcHK/vPits=",
+        "owner": "serokell",
+        "repo": "deploy-rs",
+        "rev": "b3ea6f333f9057b77efd9091119ba67089399ced",
+        "type": "github"
+      },
+      "original": {
+        "owner": "serokell",
+        "repo": "deploy-rs",
+        "type": "github"
+      }
+    },
+    "disko": {
+      "inputs": {
+        "nixpkgs": [
+          "sonata-system",
+          "lowrisc-it",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1717177033,
+        "narHash": "sha256-G3CZJafCO8WDy3dyA2EhpUJEmzd5gMJ2IdItAg0Hijw=",
+        "owner": "nix-community",
+        "repo": "disko",
+        "rev": "0274af4c92531ebfba4a5bd493251a143bc51f3c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "disko",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "sonata-system",
+          "lowrisc-it",
+          "lanzaboote",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1680392223,
+        "narHash": "sha256-n3g7QFr85lDODKt250rkZj2IFS3i4/8HBU2yKHO3tqw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "dcc36e45d054d7bb554c9cdab69093debd91a0b5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-programs-sqlite": {
+      "inputs": {
+        "nixpkgs": [
+          "sonata-system",
+          "lowrisc-it",
+          "nixpkgs"
+        ],
+        "utils": "utils"
+      },
+      "locked": {
+        "lastModified": 1717266433,
+        "narHash": "sha256-2/+a5Z6RTjqjFYjA7sY2lqqZBATamGVbOqXKbKbwDs8=",
+        "owner": "wamserma",
+        "repo": "flake-programs-sqlite",
+        "rev": "207102a62b24df0a063af3c02d36a486fa5915c2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wamserma",
+        "repo": "flake-programs-sqlite",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -36,19 +278,164 @@
         "type": "github"
       }
     },
-    "lowrisc-nix": {
+    "flake-utils_3": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs",
-        "poetry2nix": "poetry2nix",
+        "systems": "systems_4"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "sonata-system",
+          "lowrisc-it",
+          "lanzaboote",
+          "pre-commit-hooks-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "impermanence": {
+      "locked": {
+        "lastModified": 1708968331,
+        "narHash": "sha256-VUXLaPusCBvwM3zhGbRIJVeYluh2uWuqtj4WirQ1L9Y=",
+        "owner": "nix-community",
+        "repo": "impermanence",
+        "rev": "a33ef102a02ce77d3e39c25197664b7a636f9c30",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "impermanence",
+        "type": "github"
+      }
+    },
+    "lanzaboote": {
+      "inputs": {
+        "crane": "crane_2",
+        "flake-compat": "flake-compat_3",
+        "flake-parts": "flake-parts",
+        "flake-utils": [
+          "sonata-system",
+          "lowrisc-it",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "sonata-system",
+          "lowrisc-it",
+          "nixpkgs"
+        ],
+        "pre-commit-hooks-nix": "pre-commit-hooks-nix",
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1724163813,
-        "narHash": "sha256-jdVhaKwR39AqQcSIe2euQkZwsu88qRcjsehO57tchVA=",
+        "lastModified": 1682802423,
+        "narHash": "sha256-Fb5TeRTdvUlo/5Yi2d+FC8a6KoRLk2h1VE0/peMhWPs=",
+        "owner": "nix-community",
+        "repo": "lanzaboote",
+        "rev": "64b903ca87d18cef2752c19c098af275c6e51d63",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "v0.3.0",
+        "repo": "lanzaboote",
+        "type": "github"
+      }
+    },
+    "lowrisc-it": {
+      "inputs": {
+        "attic": "attic",
+        "deploy-rs": "deploy-rs",
+        "disko": "disko",
+        "flake-programs-sqlite": "flake-programs-sqlite",
+        "flake-utils": "flake-utils_2",
+        "impermanence": "impermanence",
+        "lanzaboote": "lanzaboote",
+        "lowrisc-nix": "lowrisc-nix",
+        "nixpkgs": "nixpkgs",
+        "sops-nix": "sops-nix"
+      },
+      "locked": {
+        "lastModified": 1717498311,
+        "narHash": "sha256-XzT+8N1hW3G0y64hRK2u4VN4QQ6ptPAfL9yhDHQU0Hw=",
+        "path": "/nix/store/6xl2j5knkaqmq0421xv2blrjmy5jfrm7-source",
+        "rev": "5e648226aec75c77b299750d895f560a5bc38079",
+        "revCount": 641,
+        "type": "path"
+      },
+      "original": {
+        "id": "lowrisc-it",
+        "type": "indirect"
+      }
+    },
+    "lowrisc-nix": {
+      "inputs": {
+        "flake-utils": [
+          "sonata-system",
+          "lowrisc-it",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "sonata-system",
+          "lowrisc-it",
+          "nixpkgs"
+        ],
+        "poetry2nix": "poetry2nix",
+        "rust-overlay": "rust-overlay_2"
+      },
+      "locked": {
+        "lastModified": 1717250258,
+        "narHash": "sha256-NqgMyFfIgvHik1OV1xAmQrAVJj3uEoiFaHvCwnc1vlU=",
         "owner": "lowRISC",
         "repo": "lowrisc-nix",
-        "rev": "7412a5a201df3e5837b42a9b831bdf5bb9105a3b",
+        "rev": "2df56452e54c149f6a1745143507c1af466fc10d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lowRISC",
+        "repo": "lowrisc-nix",
+        "type": "github"
+      }
+    },
+    "lowrisc-nix_2": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs_2",
+        "poetry2nix": "poetry2nix_2",
+        "rust-overlay": "rust-overlay_3"
+      },
+      "locked": {
+        "lastModified": 1729160096,
+        "narHash": "sha256-Mb201UMO84FrhcQAxDf73eqgJbeVWF7zfJxJrb9GL8U=",
+        "owner": "lowRISC",
+        "repo": "lowrisc-nix",
+        "rev": "7e387a147e477160aaf6343ce0233dc1ee2ceede",
         "type": "github"
       },
       "original": {
@@ -82,6 +469,30 @@
       "inputs": {
         "nixpkgs": [
           "sonata-system",
+          "lowrisc-it",
+          "lowrisc-nix",
+          "poetry2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1703863825,
+        "narHash": "sha256-rXwqjtwiGKJheXB43ybM8NwWB8rO2dSRrEqes0S7F5Y=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "5163432afc817cf8bd1f031418d1869e4c9d5547",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
+    "nix-github-actions_2": {
+      "inputs": {
+        "nixpkgs": [
+          "sonata-system",
           "lowrisc-nix",
           "poetry2nix",
           "nixpkgs"
@@ -103,6 +514,38 @@
     },
     "nixpkgs": {
       "locked": {
+        "lastModified": 1717144377,
+        "narHash": "sha256-F/TKWETwB5RaR8owkPPi+SPJh83AQsm6KrQAlJ8v/uA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "805a384895c696f802a9bf5bf4720f37385df547",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1678872516,
+        "narHash": "sha256-/E1YwtMtFAu2KUQKV/1+KFuReYPANM2Rzehk84VxVoc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
         "lastModified": 1723938990,
         "narHash": "sha256-9tUadhnZQbWIiYVXH8ncfGXGvkNq3Hag4RCBEMUk7MI=",
         "owner": "NixOS",
@@ -121,12 +564,14 @@
       "inputs": {
         "flake-utils": [
           "sonata-system",
+          "lowrisc-it",
           "lowrisc-nix",
           "flake-utils"
         ],
         "nix-github-actions": "nix-github-actions",
         "nixpkgs": [
           "sonata-system",
+          "lowrisc-it",
           "lowrisc-nix",
           "nixpkgs"
         ],
@@ -144,6 +589,73 @@
       "original": {
         "owner": "nix-community",
         "repo": "poetry2nix",
+        "type": "github"
+      }
+    },
+    "poetry2nix_2": {
+      "inputs": {
+        "flake-utils": [
+          "sonata-system",
+          "lowrisc-nix",
+          "flake-utils"
+        ],
+        "nix-github-actions": "nix-github-actions_2",
+        "nixpkgs": [
+          "sonata-system",
+          "lowrisc-nix",
+          "nixpkgs"
+        ],
+        "systems": "systems_5",
+        "treefmt-nix": "treefmt-nix_2"
+      },
+      "locked": {
+        "lastModified": 1723854676,
+        "narHash": "sha256-+BrHfNuXrqeE7PoV6xDaoh0joYiJkvTTCIV0fFR3THw=",
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "rev": "d650118bce34c0238b9b54f23f7f173f9e4db867",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks-nix": {
+      "inputs": {
+        "flake-compat": [
+          "sonata-system",
+          "lowrisc-it",
+          "lanzaboote",
+          "flake-compat"
+        ],
+        "flake-utils": [
+          "sonata-system",
+          "lowrisc-it",
+          "lanzaboote",
+          "flake-utils"
+        ],
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "sonata-system",
+          "lowrisc-it",
+          "lanzaboote",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1681413034,
+        "narHash": "sha256-/t7OjNQcNkeWeSq/CFLYVBfm+IEnkjoSm9iKvArnUUI=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "d3de8f69ca88fb6f8b09e5b598be5ac98d28ede5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
         "type": "github"
       }
     },
@@ -166,6 +678,64 @@
       }
     },
     "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "sonata-system",
+          "lowrisc-it",
+          "lanzaboote",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "sonata-system",
+          "lowrisc-it",
+          "lanzaboote",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1682129965,
+        "narHash": "sha256-1KRPIorEL6pLpJR04FwAqqnt4Tzcm4MqD84yhlD+XSk=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "2c417c0460b788328220120c698630947547ee83",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
+      "inputs": {
+        "flake-utils": [
+          "sonata-system",
+          "lowrisc-it",
+          "lowrisc-nix",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "sonata-system",
+          "lowrisc-it",
+          "lowrisc-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1717208326,
+        "narHash": "sha256-4gVhbC+NjSQ4c6cJvJGNCI1oTcD+8jRRNAnOF9faGCE=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "ab69b67fac9a96709fbef0b899db308ca714a120",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_3": {
       "inputs": {
         "nixpkgs": [
           "sonata-system",
@@ -194,7 +764,8 @@
           "lowrisc-nix",
           "flake-utils"
         ],
-        "lowrisc-nix": "lowrisc-nix",
+        "lowrisc-it": "lowrisc-it",
+        "lowrisc-nix": "lowrisc-nix_2",
         "nixpkgs": [
           "sonata-system",
           "lowrisc-nix",
@@ -207,16 +778,43 @@
         ]
       },
       "locked": {
-        "lastModified": 1725029535,
-        "narHash": "sha256-sT322ifokMAtDo95s5knuZICDKN11nUgLuxxPiMsAkM=",
+        "lastModified": 1730992326,
+        "narHash": "sha256-f5nC8HLorvgyiNmMX8f+X2ebHvCzjYQdsRDNVyMIR3o=",
         "owner": "lowRISC",
         "repo": "sonata-system",
-        "rev": "8f383b4a84ad8695629ceaa81c641cad7910b8ba",
+        "rev": "d410c6692bae8b579ee1b9986dd7ad1ebe077a8b",
         "type": "github"
       },
       "original": {
         "owner": "lowRISC",
         "repo": "sonata-system",
+        "type": "github"
+      }
+    },
+    "sops-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "sonata-system",
+          "lowrisc-it",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": [
+          "sonata-system",
+          "lowrisc-it",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1716692524,
+        "narHash": "sha256-sALodaA7Zkp/JD6ehgwc0UCBrSBfB4cX66uFGTsqeFU=",
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "rev": "962797a8d7f15ed7033031731d0bb77244839960",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "sops-nix",
         "type": "github"
       }
     },
@@ -264,7 +862,60 @@
         "type": "indirect"
       }
     },
+    "systems_4": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_5": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "id": "systems",
+        "type": "indirect"
+      }
+    },
     "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "sonata-system",
+          "lowrisc-it",
+          "lowrisc-nix",
+          "poetry2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1717182148,
+        "narHash": "sha256-Hi09/RoizxubRf3PHToT2Nm7TL8B/abSVa6q82uEgNI=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "03b982b77df58d5974c61c6022085bafe780c1cf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
       "inputs": {
         "nixpkgs": [
           "sonata-system",
@@ -284,6 +935,21 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     }

--- a/libraries/lcd.hh
+++ b/libraries/lcd.hh
@@ -3,7 +3,7 @@
 
 #include <algorithm>
 #include <cheri.hh>
-#include <platform-gpio.hh>
+#include <platform-pwm.hh>
 #include <platform-spi.hh>
 #include <thread.h>
 #include <utility>


### PR DESCRIPTION
This PR only touches the automotive demo enough to make it compile, but not work, which will be addressed in a separate PR due to consistency issues with the demo, likely due to the demo's reliance on undefined behaviour.

See the commit messages for more details on the changes.

This PR primarily involves updating demos to use the updated GPIO, I2C and PWM drivers, and to match the newest GPIO board input/output mappings for any instances where the `input`/`output` GPIO registers are being interfaced with directly. It also updates the LCD library/driver to match the newest hardware changes - using SPI Chip Select lines and a PWM backlight in place of the original GPIO pin interface.

This has been tested to build and run all existing software with the exception of the automotive demo, which is not fixed by this PR, and the proximity demo, as I do not have hardware on hand to test that. 