### PR TITLE
Update `sonata-software` to use the latest upstream `cheriot-rtos`

### DIFF
--- a/doc/guide/sonata-io.md
+++ b/doc/guide/sonata-io.md
@@ -35,18 +35,25 @@ For example say you wished to connect the PMOD0 SPI to SPI block 1; there are 4 
 - PMOD 0 CS (pin 1), COPI (pin 2) and SCK (pin 4) output selectors
 - SPI Block 1 CIPO input selector
 
-The code below shows how to use the pinmux driver to do this:
+The code below shows how you could use the pinmux driver to do this:
 
 ```c++
 #include <platform-pinmux.hh>
 
 ...
 
-auto pinmux = SonataPinmux();
-pinmux.output_pin_select(SonataPinmux::OutputPin::pmod0_1, 2);
-pinmux.block_input_select(SonataPinmux::BlockInput::spi_1_cipo, 3);
-pinmux.output_pin_select(SonataPinmux::OutputPin::pmod0_2, 2);
-pinmux.output_pin_select(SonataPinmux::OutputPin::pmod0_4, 2);
+auto pinmuxPinSinks = MMIO_CAPABILITY(SonataPinmux::PinSinks, pinmux_pins_sinks);
+auto pinmuxBlockSinks = MMIO_CAPABILITY(SonataPinmux::BlockSinks, pinmux_block_sinks);
+
+auto pmod0_1 = pinmuxPinSinks->get(SonataPinmux::PinSink::pmod0_1);
+auto spi_1_cipo = pinmuxBlockSinks->get(SonataPinmux::BlockSink::spi_1_cipo);
+auto pmod0_2 = pinmuxPinSinks->get(SonataPinmux::PinSink::pmod0_2);
+auto pmod0_4 = pinmuxPinSinks->get(SonataPinmux::PinSink::pmod0_4);
+
+pmod0_1.select(2);
+spi_1_cipo.select(3);
+pmod0_2.select(2);
+pmod0_4.select(2);
 ```
 
 Following this you can then use the `spi1` SPI instance to communicate with whatever SPI device is plugged into PMOD0.

--- a/examples/automotive/cheri/receive.cc
+++ b/examples/automotive/cheri/receive.cc
@@ -17,6 +17,7 @@
 using Debug = ConditionalDebug<true, "Automotive-Receive">;
 using namespace CHERI;
 using namespace sonata::lcd;
+using SonataPwm = SonataPulseWidthModulation::General;
 
 #define PWM_MAX_DUTY_CYCLE 255 // Max is 100%.
 
@@ -183,7 +184,7 @@ void pwm_signal_car(CarInfo *carInfo)
 	const uint32_t PwmDutyCycle =
 	  (SpeedOffset * DutyRange) / SpeedRange + PWM_MIN_DUTY_CYCLE;
 	auto pwm = MMIO_CAPABILITY(SonataPwm, pwm);
-	pwm->output_set(0, PWM_MAX_DUTY_CYCLE, PwmDutyCycle);
+	pwm->get<0>()->output_set(PWM_MAX_DUTY_CYCLE, PwmDutyCycle);
 }
 
 /**

--- a/libraries/lcd.cc
+++ b/libraries/lcd.cc
@@ -8,6 +8,7 @@ template<typename T>
 using Cap = CHERI::Capability<T>;
 
 using namespace sonata::lcd;
+using SonataLcdBl = SonataPulseWidthModulation::LcdBacklight;
 
 /**
  * Helper. Returns a pointer to the SPI device.
@@ -20,9 +21,9 @@ using namespace sonata::lcd;
 /**
  * Helper. Returns a pointer to the LCD's backlight PWM device.
  */
-[[nodiscard, gnu::always_inline]] static Cap<volatile SonataLcdPwm> pwm_bl()
+[[nodiscard, gnu::always_inline]] static Cap<volatile SonataLcdBl> pwm_bl()
 {
-	return MMIO_CAPABILITY(SonataLcdPwm, pwm_lcd);
+	return MMIO_CAPABILITY(SonataLcdBl, pwm_lcd);
 }
 
 static constexpr uint8_t LcdCsPin  = 0;
@@ -45,7 +46,7 @@ namespace sonata::lcd::internal
 	{
 		// Set the initial state of the LCD control pins.
 		set_chip_select(LcdDcPin, false);
-		pwm_bl()->output_set(/*index =*/0, /*period=*/1, /*duty_cycle=*/255);
+		pwm_bl()->output_set(/*period=*/1, /*duty_cycle=*/255);
 		set_chip_select(LcdCsPin, false);
 
 		// Initialise SPI driver.
@@ -83,7 +84,7 @@ namespace sonata::lcd::internal
 		// Hold LCD in reset.
 		set_chip_select(LcdRstPin, false);
 		// Turn off backlight.
-		pwm_bl()->output_set(/*index =*/0, /*period=*/0, /*duty_cycle=*/0);
+		pwm_bl()->output_set(/*period=*/0, /*duty_cycle=*/0);
 	}
 } // namespace sonata::lcd::internal
 


### PR DESCRIPTION
Updates `sonata-software` to use the latest upstream RTOS changes, including general RTOS improvements as well as updated drivers (e.g. PWM and Pinmux) which offer more fine-grained compartmentalisation and isolation of MMIO capabilities, for developing software that is more secure. This requires some minimal changes to the example code and documentation that lives inside this repository.

This has been tested to work with the existing demos/examples on the 1.0 bitstream.