### PR TITLE
Add demos that use the RPi Sense HAT LED Matrix

### DIFF
--- a/examples/all/sense_hat_demo.cc
+++ b/examples/all/sense_hat_demo.cc
@@ -1,0 +1,290 @@
+// Copyright lowRISC Contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Simple demo using the LED Matrix. Can switch between a small 8x8 Conway's
+ * Game of Life example from an initial state, and displaying some text
+ * sweeping across the LED matrix.
+ *
+ * Hold down the joystick to switch between the two demos.
+ *
+ * Refer to the comment on the `sense_hat.hh` library: be careful about using
+ * this demo when switching software / bitstream / resetting the FPGA. If used
+ * in this context, you might find that the I2C controller on the Sense HAT
+ * gets stuck, and so you need to either unplug/replug the Sense HAT or power
+ * cycle the FPGA.
+ */
+
+#include "../../libraries/sense_hat.hh"
+#include "../../third_party/display_drivers/core/m3x6_16pt.h"
+#include <compartment.h>
+#include <debug.hh>
+#include <platform-gpio.hh>
+#include <thread.h>
+
+/// Expose debugging features unconditionally for this compartment.
+using Debug  = ConditionalDebug<true, "Sense HAT">;
+using Colour = SenseHat::Colour;
+
+const Colour OnColour  = {.red = Colour::MaxRedValue, .green = 0, .blue = 0};
+const Colour OffColour = {.red = 25, .green = 25, .blue = 25};
+constexpr uint64_t GolFrameWaitMsec  = 400;
+constexpr char     DemoText[]        = "CHERIoT <3 Sonata! ";
+constexpr uint64_t TextFrameWaitMsec = 150;
+
+/// Use a custom bitmap for "g" to make presentation slightly cleaner
+constexpr uint8_t GBitmap[8] = {
+  0x00, //
+  0x06, //  ##
+  0x05, // # #
+  0x07, // ###
+  0x04, //   #
+  0x03, // ##
+  0x00, //
+  0x00, //
+};
+
+/// Game of Life starting patterns
+constexpr bool Mold[8][8] = {
+  {0, 0, 0, 0, 0, 0, 0, 0},
+  {0, 0, 0, 0, 1, 1, 0, 0},
+  {0, 0, 0, 1, 0, 0, 1, 0},
+  {0, 0, 1, 0, 1, 0, 1, 0},
+  {0, 0, 1, 0, 0, 1, 0, 0},
+  {0, 1, 0, 0, 0, 0, 0, 0},
+  {0, 0, 1, 0, 1, 0, 0, 0},
+  {0, 0, 0, 0, 0, 0, 0, 0},
+};
+
+constexpr bool Octagon2[8][8] = {
+  {0, 0, 0, 1, 1, 0, 0, 0},
+  {0, 0, 1, 0, 0, 1, 0, 0},
+  {0, 1, 0, 0, 0, 0, 1, 0},
+  {1, 0, 0, 0, 0, 0, 0, 1},
+  {1, 0, 0, 0, 0, 0, 0, 1},
+  {0, 1, 0, 0, 0, 0, 1, 0},
+  {0, 0, 1, 0, 0, 1, 0, 0},
+  {0, 0, 0, 1, 1, 0, 0, 0},
+};
+
+constexpr bool Mazing[8][8] = {
+  {0, 0, 0, 0, 0, 0, 0, 0},
+  {0, 0, 0, 1, 1, 0, 0, 0},
+  {0, 1, 0, 1, 0, 0, 0, 0},
+  {1, 0, 0, 0, 0, 0, 1, 0},
+  {0, 1, 0, 0, 0, 1, 1, 0},
+  {0, 0, 0, 0, 0, 0, 0, 0},
+  {0, 0, 0, 1, 0, 1, 0, 0},
+  {0, 0, 0, 0, 1, 0, 0, 0},
+};
+
+enum class Demo : uint8_t
+{
+	GameOfLife    = 0,
+	ScrollingText = 1,
+};
+
+void update_image(const bool state[8][8], Colour fb[64])
+{
+	// Update the pixel framebuffer based on the current GOL game state
+	for (uint8_t i = 0; i < 64u; i++)
+	{
+		fb[i] = state[i / 8u][i % 8u] ? OnColour : OffColour;
+	}
+}
+
+uint8_t get_neighbours(bool state[8][8], uint8_t y, uint8_t x)
+{
+	// Count neighbours
+	uint8_t neighbours = 0u;
+	for (int8_t ny = static_cast<int8_t>(y - 1); ny <= y + 1; ny++)
+	{
+		for (int8_t nx = static_cast<int8_t>(x - 1); nx <= x + 1; nx++)
+		{
+			if ((ny == y && nx == x) || ny < 0 || ny >= 8 || nx < 0 || nx >= 8)
+				continue;
+			neighbours += state[ny][nx];
+		}
+	}
+	return neighbours;
+}
+
+void update_gol_state(bool state[8][8])
+{
+	bool result[8][8] = {0u};
+	// Iterate through cells
+	for (uint8_t y = 0u; y < 8u; y++)
+	{
+		for (uint8_t x = 0u; x < 8u; x++)
+		{
+			uint8_t neighbours = get_neighbours(
+			  state, static_cast<int16_t>(y), static_cast<int16_t>(x));
+			// Calculate the new state and store into a temporary result array
+			if (state[y][x] && neighbours != 2u && neighbours != 3u)
+			{
+				result[y][x] = 0u;
+			}
+			else if (!state[y][x] && neighbours == 3u)
+			{
+				result[y][x] = 1u;
+			}
+			else
+			{
+				result[y][x] = state[y][x];
+			}
+		}
+	}
+	// Copy the newly calculated state back into the original 2D array
+	memcpy(state, result, sizeof(bool[8][8]));
+}
+
+void update_text_state(bool state[8][8], uint32_t *index, uint32_t *column)
+{
+	uint8_t currentChar = static_cast<uint8_t>(DemoText[*index]);
+
+	/// If at the end of the string, reset to the beginning (wrap around)
+	if (currentChar == '\0')
+	{
+		*index      = 0;
+		*column     = 0;
+		currentChar = static_cast<uint8_t>(DemoText[0]);
+	}
+
+	/// Copy all columns left by 1.
+	for (uint8_t x = 0u; x < 7u; x++)
+	{
+		for (uint8_t y = 0u; y < 8u; y++)
+		{
+			state[y][x] = state[y][x + 1];
+		}
+	}
+
+	/// Render the bitmap on the last column
+	bool noBitsInColumn = true;
+	for (uint8_t y = 1u; y < 8u; y++)
+	{
+		const uint32_t BitmapAddr = (currentChar - 32u) * 8u + y - 1u;
+		const uint8_t  Bit        = 1u << *column;
+
+		/// Retrieve bitmap
+		if (currentChar == 'g')
+		{
+			state[y][7] = (GBitmap[y - 1u] & Bit) >> *column;
+		}
+		else
+		{
+			state[y][7] = (m3x6_16ptBitmaps[BitmapAddr] & Bit) >> *column;
+		}
+
+		/* (Slightly hacky): detect gaps (columns with no bits) to determine
+		when the character ends, so that we can render this monospaced font
+		without monospacing. This won't work for every character, but is good
+		enough for our purposes. */
+		if (state[y][7])
+		{
+			noBitsInColumn = false;
+		}
+	}
+
+	/* If a gap is found, or the entire character is rendered, progress to the
+	next character to render. */
+	if ((noBitsInColumn && (currentChar != ' ')) || (*column == 6u))
+	{
+		if (++*index > sizeof(DemoText))
+		{
+			*index = 0;
+		}
+		*column = 0;
+	}
+	else
+	{
+		*column += 1;
+	}
+}
+
+void initialize_demo(Demo      currentDemo,
+                     bool      ledState[8][8],
+                     uint32_t *index,
+                     uint32_t *column)
+{
+	switch (currentDemo)
+	{
+		case Demo::GameOfLife:
+			memcpy(ledState, Octagon2, sizeof(bool[8][8]));
+			break;
+		case Demo::ScrollingText:
+			memset(ledState, 0u, sizeof(bool[8][8]));
+			*column = 0u;
+			*index  = 0u;
+			break;
+		default:
+			Debug::log("Unknown demo type to intialize: {}", currentDemo);
+			break;
+	}
+}
+
+/// Thread entry point.
+void __cheri_compartment("sense_hat_demo") test()
+{
+	Debug::log("Starting Sense HAT test");
+	Demo currentDemo = Demo::GameOfLife;
+
+	// Initialise GPIO capability for joystick inputs
+	auto gpio = MMIO_CAPABILITY(SonataGpioBoard, gpio_board);
+
+	// Initialise the Sense HAT
+	auto senseHat = SenseHat();
+
+	// Initialise a blank LED Matrix.
+	Colour fb[64] = {OffColour};
+	senseHat.set_pixels(fb);
+
+	// Initialise LED Matrix starting states
+	bool     ledState[8][8];
+	uint32_t index               = 0;
+	uint32_t column              = 0;
+	bool     joystickPrevPressed = false;
+	initialize_demo(currentDemo, ledState, &index, &column);
+
+	while (true)
+	{
+		/* If a joystick press is detected during an update, switch the demo
+		type. This is not polled in a while waiting between updates, so a press
+		can be missed between updates. */
+		bool joystickIsPressed = static_cast<uint16_t>(gpio->read_joystick()) &
+		                         static_cast<uint16_t>(SonataJoystick::Pressed);
+		if (!joystickPrevPressed && joystickIsPressed)
+		{
+			currentDemo =
+			  static_cast<Demo>((static_cast<uint8_t>(currentDemo) + 1) % 2);
+			thread_millisecond_wait(500);
+			initialize_demo(currentDemo, ledState, &index, &column);
+			joystickPrevPressed = true;
+		}
+		if (joystickPrevPressed && !joystickIsPressed)
+		{
+			joystickPrevPressed = false;
+		}
+
+		switch (currentDemo)
+		{
+			case Demo::GameOfLife:
+				/// Every frame, update the game state and LED matrix.
+				thread_millisecond_wait(GolFrameWaitMsec);
+				update_image(ledState, fb);
+				senseHat.set_pixels(fb);
+				update_gol_state(ledState);
+				break;
+			case Demo::ScrollingText:
+				/// Every frame, update the scrolling text and LED matrix
+				thread_millisecond_wait(TextFrameWaitMsec);
+				update_image(ledState, fb);
+				senseHat.set_pixels(fb);
+				update_text_state(ledState, &index, &column);
+				break;
+			default:
+				thread_millisecond_wait(100UL);
+				Debug::log("Unknown demo type: {}", currentDemo);
+		}
+	}
+}

--- a/examples/all/xmake.lua
+++ b/examples/all/xmake.lua
@@ -22,3 +22,7 @@ compartment("rgbled_lerp")
 compartment("proximity_sensor_example")
     add_deps("debug")
     add_files("proximity_sensor_example.cc")
+
+compartment("sense_hat_demo")
+    add_deps("debug", "sense_hat")
+    add_files("sense_hat_demo.cc", "../../third_party/display_drivers/core/m3x6_16pt.c")

--- a/examples/all/xmake.lua
+++ b/examples/all/xmake.lua
@@ -20,7 +20,7 @@ compartment("rgbled_lerp")
     add_files("rgbled_lerp.cc")
 
 compartment("proximity_sensor_example")
-    add_deps("debug")
+    add_deps("debug", "sense_hat")
     add_files("proximity_sensor_example.cc")
 
 compartment("sense_hat_demo")

--- a/examples/xmake.lua
+++ b/examples/xmake.lua
@@ -139,6 +139,44 @@ firmware("proximity_test")
     after_link(convert_to_uf2)
 
 
+-- Demo that uses a Sense HAT's LED Matrix
+firmware("sense_hat_leds")
+    add_deps("freestanding", "led_walk_raw", "lcd_test", "rgbled_lerp", "sense_hat_demo")
+    on_load(function(target)
+        target:values_set("board", "$(board)")
+        target:values_set("threads", {
+            {
+                compartment = "led_walk_raw",
+                priority = 2,
+                entry_point = "start_walking",
+                stack_size = 0x200,
+                trusted_stack_frames = 1
+            },
+            {
+                compartment = "lcd_test",
+                priority = 2,
+                entry_point = "lcd_test",
+                stack_size = 0x1000,
+                trusted_stack_frames = 1
+            },
+            {
+                compartment = "rgbled_lerp",
+                priority = 2,
+                entry_point = "lerp_rgbleds",
+                stack_size = 0x200,
+                trusted_stack_frames = 1
+            },
+            {
+                compartment = "sense_hat_demo",
+                priority = 2,
+                entry_point = "test",
+                stack_size = 0x1000,
+                trusted_stack_frames = 1
+            }
+        }, {expand = false})
+    end)
+    after_link(convert_to_uf2)
+
 -- Demo that does proximity test as well as LCD screen, etc for demos.
 firmware("leds_and_lcd")
     add_deps("freestanding", "led_walk_raw", "lcd_test", "rgbled_lerp")

--- a/examples/xmake.lua
+++ b/examples/xmake.lua
@@ -115,7 +115,7 @@ firmware("sonata_proximity_demo")
                 compartment = "proximity_sensor_example",
                 priority = 2,
                 entry_point = "run",
-                stack_size = 0x200,
+                stack_size = 0x1000,
                 trusted_stack_frames = 1
             }
         }, {expand = false})
@@ -131,7 +131,7 @@ firmware("proximity_test")
                 compartment = "proximity_sensor_example",
                 priority = 2,
                 entry_point = "run",
-                stack_size = 0x200,
+                stack_size = 0x1000,
                 trusted_stack_frames = 1
             }
         }, {expand = false})

--- a/libraries/sense_hat.cc
+++ b/libraries/sense_hat.cc
@@ -1,0 +1,74 @@
+// Copyright lowRISC Contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sense_hat.hh"
+#include <cheri.hh>
+#include <platform-i2c.hh>
+
+using namespace CHERI;
+
+/**
+ * Helper. Returns a pointer to the I2C device.
+ */
+[[nodiscard, gnu::always_inline]] static Capability<volatile OpenTitanI2c> i2c()
+{
+	return MMIO_CAPABILITY(OpenTitanI2c, i2c1);
+}
+
+void __cheri_libcall Internal::init_i2c()
+{
+	/* Increase the reliability of the Sense HAT I2C against controller halts
+	in case the I2C Controller gets into a bad state while loading demos. */
+	i2c()->control = i2c()->control & ~(OpenTitanI2c::ControlEnableHost |
+	                                    OpenTitanI2c::ControlEnableTarget);
+	if (i2c()->interrupt_is_asserted(OpenTitanI2cInterrupt::ControllerHalt))
+	{
+		i2c()->reset_controller_events();
+	}
+
+	/* Initialise the I2C controller as normal. */
+	i2c()->reset_fifos();
+	i2c()->host_mode_set();
+	i2c()->speed_set(100);
+}
+
+bool __cheri_libcall SenseHat::set_pixels(Colour pixels8x8[64])
+{
+	uint8_t  writeBuffer[1 + 64 * 3] = {0x0u};
+	uint32_t i                       = 0u;
+	writeBuffer[i++]                 = 0x00u; // Address
+	for (uint8_t row = 0u; row < 8u; row++)
+	{
+		for (uint8_t column = 0u; column < 8u; column++)
+		{
+			uint32_t index = row * 8u + column;
+			if (pixels8x8[index].red > Colour::MaxRedValue)
+			{
+				Debug::log("{}:{} exceeds maximum red.", row, column);
+				return false;
+			}
+			writeBuffer[i++] = pixels8x8[index].red;
+		}
+		for (uint8_t column = 0u; column < 8u; column++)
+		{
+			uint32_t index = row * 8u + column;
+			if (pixels8x8[index].green > Colour::MaxGreenValue)
+			{
+				Debug::log("{}:{} exceeds maximum green.", row, column);
+				return false;
+			}
+			writeBuffer[i++] = pixels8x8[index].green;
+		}
+		for (uint8_t column = 0u; column < 8u; column++)
+		{
+			uint32_t index = row * 8u + column;
+			if (pixels8x8[index].blue > Colour::MaxBlueValue)
+			{
+				Debug::log("{}:{} exceeds maximum blue.", row, column);
+				return false;
+			}
+			writeBuffer[i++] = pixels8x8[index].blue;
+		}
+	}
+	return i2c()->blocking_write(0x46u, writeBuffer, sizeof(writeBuffer), true);
+}

--- a/libraries/sense_hat.hh
+++ b/libraries/sense_hat.hh
@@ -1,0 +1,73 @@
+// Copyright lowRISC Contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * A driver used for writing to the Raspberry Pi Sense HAT LED Matrix
+ * via an I2C connection.
+ *
+ * Warning: Aborting the I2C transaction (e.g. resetting the FPGA, switching
+ * software slot or bitstream) can cause the in-progress I2C transaction which
+ * is writing the entire framebuffer to be interrupted. This can leave the I2C
+ * controller on the Sense HAT in a bad state, with no easy mechanism for
+ * resetting it via the OpenTitan I2C controller. You should be aware of this
+ * if you plan to use and rely on this driver. If the I2C controller does get
+ * into a bad state, you must unplug (for a few seconds) and replug the Sense
+ * HAT, or power cycle the entire Sonata FPGA. Do not use this driver if you
+ * plan to switch software slots / bitstreams regularly.
+ */
+
+#include <algorithm>
+#include <debug.hh>
+#include <utility>
+
+namespace Internal
+{
+	void __cheri_libcall init_i2c();
+} // namespace Internal
+
+class SenseHat
+{
+	private:
+	/// Flag set when we're debugging this driver.
+	static constexpr bool DebugSenseHat = true;
+
+	/// Helper for conditional debug logs and assertions.
+	using Debug = ConditionalDebug<DebugSenseHat, "Sense HAT">;
+
+	public:
+	struct Colour
+	{
+		// Sense HAT LED Matrix uses RGB 565
+		static constexpr uint8_t RedBits   = 5;
+		static constexpr uint8_t GreenBits = 6;
+		static constexpr uint8_t BlueBits  = 5;
+
+		// Maximum values for each field, calculated from the number of bits
+		static constexpr uint8_t MaxRedValue   = (1 << RedBits) - 1;
+		static constexpr uint8_t MaxGreenValue = (1 << GreenBits) - 1;
+		static constexpr uint8_t MaxBlueValue  = (1 << BlueBits) - 1;
+
+		// Colour fields
+		uint8_t red;
+		uint8_t green;
+		uint8_t blue;
+	} __attribute__((packed));
+
+	/**
+	 * A constructor for the Sense HAT driver. Initialises the I2C controller
+	 * that will communicate with the Sense HAT's I2C Controller to write to
+	 * its LED Matrix.
+	 */
+	SenseHat()
+	{
+		Internal::init_i2c();
+	}
+
+	/**
+	 * Set the values of all pixels in the 8x8 LED Matrix on the Sense HAT
+	 * via an I2C connection. Will block until the entire array has been
+	 * written. Values are read from `pixels8x8` in row-major order (i.e.
+	 * all of row 1, then all of row 2, etc.)
+	 */
+	bool __cheri_libcall set_pixels(Colour pixels8x8[64]);
+};

--- a/libraries/xmake.lua
+++ b/libraries/xmake.lua
@@ -9,3 +9,7 @@ library("lcd")
   add_files("../third_party/display_drivers/core/lucida_console_12pt.c")
   add_files("../third_party/display_drivers/st7735/lcd_st7735.c")
   add_files("lcd.cc")
+
+library("sense_hat")
+  set_default(false)
+  add_files("sense_hat.cc")


### PR DESCRIPTION
This PR adds some small code to make use of our I2C controller to write to the Raspberry Pi Sense HAT LED Matrix shift register, such that we can render small 8x8 RGB565 images on this LED matrix.

I've then updated the existing proximity demo to add an optionally enabled LED matrix output. As you move your hand closer to the proximity sensor, the LED matrix fills up more to indicate the proximity. This does switch the proximity sensor to use I2C0 rather than I2C1 (and thus the qwiic0 connector) due to some issues with conflicts on the Sense HAT's I2C controller.

This PR also includes a new demo that just uses the Sense HAT: this demo implement's Conway's Game of Life on the 8x8 LED matrix, with the option of pressing down on the joystick to switch to/from a demo implementing some scrolling text on the LED matrix.

Note: you aren't particularly meant to be using the Sense HAT in this way (instead, you should communicate with a framebuffer on a system running Linux), so this method of interaction isn't documented anywhere online. I've figured out what I can but there might still be some small issues in the library implementation.

Try running the `sense_hat_demo` or the `sonata_proximity_demo` (with `#define SENSE_HAT_AVAILABLE true`) with a Sense HAT locally to test this.