### PR TITLE
Fix Heartbleed demo legacy lock-up due to 32-bit mcycle read

### DIFF
--- a/examples/heartbleed/legacy/heartbleed.h
+++ b/examples/heartbleed/legacy/heartbleed.h
@@ -52,7 +52,19 @@ void write_to_uart(const char *format, ...)
 		write_to_uart(__VA_ARGS__);                                            \
 	}
 
-#define rdcycle64 get_mcycle
+uint64_t rdcycle64()
+{
+	uint32_t mcycle_high, mcycle_low;
+	__asm__ volatile("1: "
+	                 "csrr t0, mcycleh\n"
+	                 "csrr %0, mcycle\n"
+	                 "csrr %1, mcycleh\n"
+	                 "bne t0, %1, 1b"
+	                 : "=r"(mcycle_low), "=r"(mcycle_high)
+	                 :
+	                 : "t0");
+	return ((uint64_t)mcycle_high << 32) | mcycle_low;
+}
 
 /**
  * @brief Read the current GPIO joystick state.


### PR DESCRIPTION
*Note*: Ideally merge after #74 to pull in the fixes necessary to get the Heartbleed demo to compile first.

The legacy demo unintentionally aliased a 32-bit `rdcycle` function to `rdcycle64`, and used its 32-bit output as a 64-bit value. This caused an overflow in the value of `mcycle` that was read after a short while of running, which left the demo stuck and unable to progress in its legacy component. Specifically, 
$$\frac{2^{32} - 1}{40 * 1000 * 1000} \approx 1$$ min 47 s.
So after around 2 minutes the legacy component of the demo will stop working.

This PR replaces this function with an actual 64-bit mcycle read using the low/high registers appropriately. It will now take >10000 years to overflow, so I've opted not to add additional logic to catch overflows here.