### PR TITLE
[doc] update workshop exercises instructions for v1.1 branch

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -110,7 +110,7 @@ Nix can and will build everything from source if it can't find a cached version,
 Clone the Sonata software repository, *making sure to recursively clone submodules as well*, then navigate into it.
 
 ```sh
-git clone --branch v1.0 \
+git clone --branch v1.1 \
     --recurse-submodule \
     https://github.com/lowRISC/sonata-software.git
 cd sonata-software

--- a/exercises/firmware_auditing/README.md
+++ b/exercises/firmware_auditing/README.md
@@ -44,7 +44,7 @@ To convert the undefined value to a Boolean, we use the `default` keyword, which
 We can run this policy on our example firmware using the following command:
 
 ```sh
-cheriot-audit --board=cheriot-rtos/sdk/boards/sonata.json \
+cheriot-audit --board=cheriot-rtos/sdk/boards/sonata-prerelease.json \
               --firmware-report=build/cheriot/cheriot/release/firmware_auditing_part_1.json \
               --module=exercises/firmware_auditing/part_1/no_sealed_capabilities.rego \
               --query='data.no_seal.valid'
@@ -138,7 +138,7 @@ Finally, we create a simple Boolean `valid` rule which combines our two conditio
 
 Now, we can audit the firmware for this exercise by using the following command:
 ```sh
-cheriot-audit --board=cheriot-rtos/sdk/boards/sonata.json \
+cheriot-audit --board=cheriot-rtos/sdk/boards/sonata-prerelease.json \
               --firmware-report=build/cheriot/cheriot/release/firmware_auditing_part_2.json \
               --module=exercises/firmware_auditing/part_2/interrupt_disables.rego \
               --query='data.interrupts.valid'
@@ -203,7 +203,7 @@ For this exercise, we decide that all sealed allocator capabilities must be vali
 
 We can audit our firmware using the following command:
 ```sh
-cheriot-audit --board=cheriot-rtos/sdk/boards/sonata.json \
+cheriot-audit --board=cheriot-rtos/sdk/boards/sonata-prerelease.json \
               --firmware-report=build/cheriot/cheriot/release/firmware_auditing_part_3.json \
               --module=exercises/firmware_auditing/part_3/malloc_check.rego \
               --query='data.malloc_check.valid'

--- a/exercises/hardware_access_control/README.md
+++ b/exercises/hardware_access_control/README.md
@@ -118,13 +118,13 @@ However, when run against the part 1 firmware image's report it will return fals
 ```sh
 # This should return true
 cheriot-audit \
-    --board cheriot-rtos/sdk/boards/sonata-1.1.json \
+    --board cheriot-rtos/sdk/boards/sonata-prerelease.json \
     --module exercises/hardware_access_control/part_3/gpio_access.rego \
     --query "data.gpio_access.only_gpio_access_has_access" \
     --firmware-report "build/cheriot/cheriot/release/hardware_access_part_2.json"
 # This should return false
 cheriot-audit \
-    --board cheriot-rtos/sdk/boards/sonata-1.1.json \
+    --board cheriot-rtos/sdk/boards/sonata-prerelease.json \
     --module exercises/hardware_access_control/part_3/gpio_access.rego \
     --query "data.gpio_access.only_gpio_access_has_access" \
     --firmware-report "build/cheriot/cheriot/release/hardware_access_part_1.json"
@@ -135,7 +135,7 @@ We can use this to restrict which compartments have access to the GPIO via `gpio
 
 ```sh
 cheriot-audit \
-    --board cheriot-rtos/sdk/boards/sonata-1.1.json \
+    --board cheriot-rtos/sdk/boards/sonata-prerelease.json \
     --module exercises/hardware_access_control/part_3/gpio_access.rego \
     --query "data.gpio_access.whitelisted_compartments_only" \
     --firmware-report "build/cheriot/cheriot/release/hardware_access_part_2.json"


### PR DESCRIPTION
This updates the instructions for the workshop exercises to use the file paths present on the v1.1 branch, as that is the latest branch that both tests successfully work on.